### PR TITLE
PVRE reporting using SSM for Mac Instances in beta-infra

### DIFF
--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -5,7 +5,7 @@ import { ArtifactBucketCloudfrontStack } from './artifact-bucket-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { MacRunnerStack } from './mac-runner-stack';
 import { ContinuousIntegrationStack } from './continuous-integration-stack';
-import { PVREReportingStack } from '../lib/pvre-reporting-stack';
+import { PVREReportingStack } from './pvre-reporting-stack';
 
 export enum ENVIRONMENT_STAGE {
   Beta,

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -5,6 +5,7 @@ import { ArtifactBucketCloudfrontStack } from './artifact-bucket-cloudfront';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { MacRunnerStack } from './mac-runner-stack';
 import { ContinuousIntegrationStack } from './continuous-integration-stack';
+import { PVREReportingStack } from '../lib/pvre-reporting-stack';
 
 export enum ENVIRONMENT_STAGE {
   Beta,
@@ -72,5 +73,8 @@ export class FinchPipelineAppStage extends cdk.Stage {
     this.cloudfrontBucket = artifactBucketCloudfrontStack.bucket;
 
     new ContinuousIntegrationStack(this, 'FinchContinuousIntegrationStack', this.stageName);
+    if (props?.environmentStage == ENVIRONMENT_STAGE.Beta) {
+      new PVREReportingStack(this, 'PVREReportingStack');
+    }
   }
 }

--- a/lib/mac-runner-stack.ts
+++ b/lib/mac-runner-stack.ts
@@ -3,6 +3,7 @@ import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { readFileSync } from 'fs';
 import { Construct } from 'constructs';
+import { Tags } from 'aws-cdk-lib';
 
 // the AMI is regional, which means an AMI has diferrent ids in differrent regions
 // when overriding the macOSVersion or amiSearchString props, please make sure that the
@@ -70,6 +71,10 @@ export class MacRunnerStack extends cdk.Stack {
         }
       ]
     });
+
+    //Add the tag for SSM PVRE reporting. This tag is used in the pvre-reporting-template.yml file. 
+    // See Resources.InventoryCollection.Properties.Targets property in pvre-reporting-template.yml file.
+    Tags.of(macInstance).add('PVRE-Reporting', 'SSM')
 
     const cfnInstance = macInstance.node.defaultChild as ec2.CfnInstance;
     cfnInstance.addPropertyOverride('Tenancy', 'host');

--- a/lib/mac-runner-stack.ts
+++ b/lib/mac-runner-stack.ts
@@ -4,6 +4,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import { readFileSync } from 'fs';
 import { Construct } from 'constructs';
 import { Tags } from 'aws-cdk-lib';
+import { ENVIRONMENT_STAGE } from './finch-pipeline-app-stage';
 
 // the AMI is regional, which means an AMI has diferrent ids in differrent regions
 // when overriding the macOSVersion or amiSearchString props, please make sure that the
@@ -18,6 +19,7 @@ interface MacRunnerStackProps extends cdk.StackProps {
   amiSearchString?: string;
   hostType?: string;
   architecture?: string;
+  environmentStage?: ENVIRONMENT_STAGE
 }
 
 export class MacRunnerStack extends cdk.Stack {
@@ -74,7 +76,9 @@ export class MacRunnerStack extends cdk.Stack {
 
     //Add the tag for SSM PVRE reporting. This tag is used in the pvre-reporting-template.yml file. 
     // See Resources.InventoryCollection.Properties.Targets property in pvre-reporting-template.yml file.
-    Tags.of(macInstance).add('PVRE-Reporting', 'SSM')
+    if(props?.environmentStage == ENVIRONMENT_STAGE.Beta) {
+      Tags.of(macInstance).add('PVRE-Reporting', 'SSM')
+    }
 
     const cfnInstance = macInstance.node.defaultChild as ec2.CfnInstance;
     cfnInstance.addPropertyOverride('Tenancy', 'host');

--- a/lib/pvre-reporting-stack.ts
+++ b/lib/pvre-reporting-stack.ts
@@ -1,0 +1,13 @@
+import * as cdk from "aws-cdk-lib";
+import * as cfninc from 'aws-cdk-lib/cloudformation-include';
+import { Construct } from 'constructs';
+
+export class PVREReportingStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    new cfninc.CfnInclude(this, "PVREReportingTemplate", {
+      templateFile: "lib/pvre-reporting-template.yml",
+    });
+  }
+}

--- a/lib/pvre-reporting-template.yml
+++ b/lib/pvre-reporting-template.yml
@@ -1,0 +1,133 @@
+Resources:
+  InventoryCollection:
+    Type: "AWS::SSM::Association"
+    Properties:
+      Name: {Ref: PvreInventoryCollectionDocument}
+      AssociationName:
+        Fn::Sub: "${AWS::AccountId}-InventoryCollection"
+      ScheduleExpression: "rate(12 hours)"
+      Targets:
+        - Key: "tag:PVRE-Reporting"
+          Values:
+            - "SSM"
+  PvreReporting:
+    Type: "AWS::SSM::ResourceDataSync"
+    Properties:
+      BucketName:
+        Fn::Sub: "pvrev2-prod-${AWS::Region}-ssm-updates"
+      BucketRegion:
+        Ref: "AWS::Region"
+      SyncFormat: "JsonSerDe"
+      SyncName:
+        Fn::Sub: "${AWS::AccountId}-PvreReporting"
+  PvreInventoryCollectionDocument:
+    Type: "AWS::SSM::Document"
+    Properties:
+      Name:
+        Fn::Sub: "PVREInventoryCollectionDocument"
+      DocumentType: "Command"
+      Content:
+        schemaVersion: "2.2"
+        description: "Collect software inventory and kernel information"
+        parameters:
+          applications:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional) Collect data for installed applications."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          awsComponents:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional) Collect data for AWS Components like amazon-ssm-agent."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          files:
+            type: "String"
+            default: ""
+            description: "<p>(Optional, requires SSMAgent version 2.2.64.0 and above)<br/><br/>Linux example:<br/><em>[{\"Path\":\"/usr/bin\", \"Pattern\":[\"aws*\", \"*ssm*\"],\"Recursive\":false},{\"Path\":\"/var/log\", \"Pattern\":[\"amazon*.*\"], \"Recursive\":true, \"DirScanLimit\":1000}]<br/></em><br/>Windows example:<br/><em>[{\"Path\":\"%PROGRAMFILES%\", \"Pattern\":[\"*.exe\"],\"Recursive\":true}]</em><br/><br/>Learn More: http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-inventory-about.html#sysman-inventory-file-and-registry  </p>"
+            displayType: "textarea"
+          networkConfig:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional) Collect data for Network configurations."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          windowsUpdates:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional, Windows OS only) Collect data for all Windows Updates."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          instanceDetailedInformation:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional) Collect additional information about the instance, including the CPU model, speed, and the number of cores, to name a few."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          services:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional, Windows OS only, requires SSMAgent version 2.2.64.0 and above) Collect data for service configurations."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          windowsRegistry:
+            type: "String"
+            default: ""
+            description: "<p>(Optional, Windows OS only, requires SSMAgent version 2.2.64.0 and above)<br/><br/>Example:<br />[{\"Path\":\"HKEY_CURRENT_CONFIG\\System\",\"Recursive\":true},{\"Path\":\"HKEY_LOCAL_MACHINE\\SOFTWARE\\Amazon\\MachineImage\", \"ValueNames\":[\"AMIName\"]}]<br/><br/>Learn More: http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-inventory-about.html#sysman-inventory-file-and-registry </p>"
+            displayType: "textarea"
+          windowsRoles:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional, Windows OS only, requires SSMAgent version 2.2.64.0 and above) Collect data for Microsoft Windows role configurations."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          customInventory:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional) Collect data for custom inventory."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+          billingInfo:
+            type: "String"
+            default: "Enabled"
+            description: "(Optional) Collect billing info for license included applications."
+            allowedValues:
+              - "Enabled"
+              - "Disabled"
+        mainSteps:
+          - action: "aws:runShellScript"
+            name: "collectCustomInventoryItems"
+            inputs:
+              timeoutSeconds: 7200
+              runCommand:
+                - "#!/bin/bash"
+                - "token=$(curl --silent --show-error --retry 3 -X PUT \"http://169.254.169.254/latest/api/token\" -H \"X-aws-ec2-metadata-token-ttl-seconds: 21600\")"
+                - "instance_id=$(curl --silent --show-error --retry 3 -H \"X-aws-ec2-metadata-token: $token\" http://169.254.169.254/latest/meta-data/instance-id)"
+                - "kernel_version=$(uname -r)"
+                - "content=\"{\\\"SchemaVersion\\\": \\\"1.0\\\", \\\"TypeName\\\": \\\"Custom:SystemInfo\\\", \\\"Content\\\": {\\\"KernelVersion\\\": \\\"$kernel_version\\\"}}\""
+                - "dir_path=\"/var/lib/amazon/ssm/$instance_id/inventory/custom\""
+                - "mkdir -p $dir_path"
+                - "echo $content > $dir_path/CustomSystemInfo.json"
+          - action: "aws:softwareInventory"
+            name: "collectSoftwareInventoryItems"
+            inputs:
+              applications: "{{ applications }}"
+              awsComponents: "{{ awsComponents }}"
+              networkConfig: "{{ networkConfig }}"
+              files: "{{ files }}"
+              services: "{{ services }}"
+              windowsRoles: "{{ windowsRoles }}"
+              windowsRegistry: "{{ windowsRegistry}}"
+              windowsUpdates: "{{ windowsUpdates }}"
+              instanceDetailedInformation: "{{ instanceDetailedInformation }}"
+              billingInfo: "{{ billingInfo }}"
+              customInventory: "{{ customInventory }}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.5.2",
-        "@types/node": "18.13.0",
+        "@types/node": "18.14.0",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
         "aws-cdk": "2.65.0",
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -5499,9 +5499,9 @@
       }
     },
     "@types/node": {
-      "version": "18.13.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
-      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
+      "version": "18.14.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
+      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "finch-aws-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.62.2",
+        "aws-cdk-lib": "2.64.0",
         "axios": "^1.3.0",
         "constructs": "^10.1.218",
         "node-fetch": "^2.6.7",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.49",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz",
-      "integrity": "sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg=="
+      "version": "2.2.62",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.62.tgz",
+      "integrity": "sha512-oU6HChRTFDXDy3yg+fGGF2EZuxwM2flF791RehcFoStw2Rbf6F/BRSudfCpziafv1MPhBUF1wSrPScCycaIFAA=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -54,9 +54,9 @@
       "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz",
-      "integrity": "sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ=="
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.51.tgz",
+      "integrity": "sha512-HNevmp8hAnOM3SuIJxUvNyKk7v2j2VZ1LEE+IPcTXCei7Mr0P6jb/ocl423jM95qi0bMzrjdmAHNiBx2boZl3w=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.62.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.62.2.tgz",
-      "integrity": "sha512-ynyoEFQckICFJzbUd89pWjol3GGbxRF05E8BCPEyy++vLHJZdqaJxRL4REl4lrdznnkb1kvxtBSGg4cOkR4o3w==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
+      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1298,16 +1298,16 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.49",
+        "@aws-cdk/asset-awscli-v1": "^2.2.52",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.2.0",
+        "punycode": "^2.3.0",
         "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
@@ -1427,7 +1427,7 @@
       }
     },
     "node_modules/aws-cdk-lib/node_modules/punycode": {
-      "version": "2.2.0",
+      "version": "2.3.0",
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4668,9 +4668,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.49",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.49.tgz",
-      "integrity": "sha512-Qd5bdLlC/sphWQQPNn7etKXWCh+fij7DWxtkIwvhhZ+LM6UEApGLS8sBLBQcRO2ZQdEuNb+zeClUy+3DNojfeg=="
+      "version": "2.2.62",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.62.tgz",
+      "integrity": "sha512-oU6HChRTFDXDy3yg+fGGF2EZuxwM2flF791RehcFoStw2Rbf6F/BRSudfCpziafv1MPhBUF1wSrPScCycaIFAA=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -4678,9 +4678,9 @@
       "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.38",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.38.tgz",
-      "integrity": "sha512-BBwAjORhuUkTGO3CxGS5Evcp5n20h9v06Sftn2R1DuSm8zIoUlPsNlI1HUk8XqYuoEI4aD7IKRQBLglv09ciJQ=="
+      "version": "2.0.51",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.51.tgz",
+      "integrity": "sha512-HNevmp8hAnOM3SuIJxUvNyKk7v2j2VZ1LEE+IPcTXCei7Mr0P6jb/ocl423jM95qi0bMzrjdmAHNiBx2boZl3w=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -5663,20 +5663,20 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.62.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.62.2.tgz",
-      "integrity": "sha512-ynyoEFQckICFJzbUd89pWjol3GGbxRF05E8BCPEyy++vLHJZdqaJxRL4REl4lrdznnkb1kvxtBSGg4cOkR4o3w==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
+      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.49",
+        "@aws-cdk/asset-awscli-v1": "^2.2.52",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.38",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
         "ignore": "^5.2.4",
         "jsonschema": "^1.4.1",
         "minimatch": "^3.1.2",
-        "punycode": "^2.2.0",
+        "punycode": "^2.3.0",
         "semver": "^7.3.8",
         "yaml": "1.10.2"
       },
@@ -5754,7 +5754,7 @@
           }
         },
         "punycode": {
-          "version": "2.2.0",
+          "version": "2.3.0",
           "bundled": true
         },
         "semver": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "finch-aws-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.64.0",
+        "aws-cdk-lib": "2.65.0",
         "axios": "^1.3.3",
         "constructs": "^10.1.250",
         "node-fetch": "^2.6.7",
@@ -44,9 +44,9 @@
       }
     },
     "node_modules/@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.62",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.62.tgz",
-      "integrity": "sha512-oU6HChRTFDXDy3yg+fGGF2EZuxwM2flF791RehcFoStw2Rbf6F/BRSudfCpziafv1MPhBUF1wSrPScCycaIFAA=="
+      "version": "2.2.69",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.69.tgz",
+      "integrity": "sha512-sKhINBDXKc9cad+4ghBsn6nB63ci7KcO7Vb2FswBI36Z7lkaIkz51pPwmVWn8AsYNOvCpcaCxUx0zngCbQOluQ=="
     },
     "node_modules/@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -54,9 +54,9 @@
       "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
     },
     "node_modules/@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.51.tgz",
-      "integrity": "sha512-HNevmp8hAnOM3SuIJxUvNyKk7v2j2VZ1LEE+IPcTXCei7Mr0P6jb/ocl423jM95qi0bMzrjdmAHNiBx2boZl3w=="
+      "version": "2.0.58",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.58.tgz",
+      "integrity": "sha512-7BTzPo1tBw1tTYEmWNO0nS+bTJ/Ikg2qpFQZBb0GedEJ1v713IyRoySlKADAXAaMPJU9Gg05LCuJy+cs7RUDMQ=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.18.6",
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.65.0.tgz",
+      "integrity": "sha512-yTeBe9+Li8ZHZICJc0y1uarbSruc3KIXP1KC7tjVrkg+ye7EE8eJTZm7+PpJd6O0ciPinn/k/dE9gHwUImygGA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1298,9 +1298,9 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-awscli-v1": "^2.2.65",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.54",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
@@ -4668,9 +4668,9 @@
       }
     },
     "@aws-cdk/asset-awscli-v1": {
-      "version": "2.2.62",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.62.tgz",
-      "integrity": "sha512-oU6HChRTFDXDy3yg+fGGF2EZuxwM2flF791RehcFoStw2Rbf6F/BRSudfCpziafv1MPhBUF1wSrPScCycaIFAA=="
+      "version": "2.2.69",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-awscli-v1/-/asset-awscli-v1-2.2.69.tgz",
+      "integrity": "sha512-sKhINBDXKc9cad+4ghBsn6nB63ci7KcO7Vb2FswBI36Z7lkaIkz51pPwmVWn8AsYNOvCpcaCxUx0zngCbQOluQ=="
     },
     "@aws-cdk/asset-kubectl-v20": {
       "version": "2.1.1",
@@ -4678,9 +4678,9 @@
       "integrity": "sha512-U1ntiX8XiMRRRH5J1IdC+1t5CE89015cwyt5U63Cpk0GnMlN5+h9WsWMlKlPXZR4rdq/m806JRlBMRpBUB2Dhw=="
     },
     "@aws-cdk/asset-node-proxy-agent-v5": {
-      "version": "2.0.51",
-      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.51.tgz",
-      "integrity": "sha512-HNevmp8hAnOM3SuIJxUvNyKk7v2j2VZ1LEE+IPcTXCei7Mr0P6jb/ocl423jM95qi0bMzrjdmAHNiBx2boZl3w=="
+      "version": "2.0.58",
+      "resolved": "https://registry.npmjs.org/@aws-cdk/asset-node-proxy-agent-v5/-/asset-node-proxy-agent-v5-2.0.58.tgz",
+      "integrity": "sha512-7BTzPo1tBw1tTYEmWNO0nS+bTJ/Ikg2qpFQZBb0GedEJ1v713IyRoySlKADAXAaMPJU9Gg05LCuJy+cs7RUDMQ=="
     },
     "@babel/code-frame": {
       "version": "7.18.6",
@@ -5663,13 +5663,13 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.64.0.tgz",
-      "integrity": "sha512-IrgL7thb6TeOyHgyR/qKWTdA9FBb9lv7Z9QPDzCNJlkKI+0ANjYHy3RYV8Gd+1+kc6l8DG9Z1elij40YCr/Ptg==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.65.0.tgz",
+      "integrity": "sha512-yTeBe9+Li8ZHZICJc0y1uarbSruc3KIXP1KC7tjVrkg+ye7EE8eJTZm7+PpJd6O0ciPinn/k/dE9gHwUImygGA==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.52",
+        "@aws-cdk/asset-awscli-v1": "^2.2.65",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.42",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.54",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "finch-aws-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.65.0",
+        "aws-cdk-lib": "2.66.0",
         "axios": "^1.3.3",
         "constructs": "^10.1.256",
         "node-fetch": "^2.6.7",
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.65.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.65.0.tgz",
-      "integrity": "sha512-yTeBe9+Li8ZHZICJc0y1uarbSruc3KIXP1KC7tjVrkg+ye7EE8eJTZm7+PpJd6O0ciPinn/k/dE9gHwUImygGA==",
+      "version": "2.66.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.66.0.tgz",
+      "integrity": "sha512-Qmw+lB8uFO+wJX8czw05ciUJObB5gJ5euOXYXXC9BuFPMy1WTA+HYqgSRvgv2mIEnjQb1zlG05oNalvH24Ha7Q==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -1298,9 +1298,9 @@
         "yaml"
       ],
       "dependencies": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.65",
+        "@aws-cdk/asset-awscli-v1": "^2.2.69",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.54",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.58",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",
@@ -5663,13 +5663,13 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.65.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.65.0.tgz",
-      "integrity": "sha512-yTeBe9+Li8ZHZICJc0y1uarbSruc3KIXP1KC7tjVrkg+ye7EE8eJTZm7+PpJd6O0ciPinn/k/dE9gHwUImygGA==",
+      "version": "2.66.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.66.0.tgz",
+      "integrity": "sha512-Qmw+lB8uFO+wJX8czw05ciUJObB5gJ5euOXYXXC9BuFPMy1WTA+HYqgSRvgv2mIEnjQb1zlG05oNalvH24Ha7Q==",
       "requires": {
-        "@aws-cdk/asset-awscli-v1": "^2.2.65",
+        "@aws-cdk/asset-awscli-v1": "^2.2.69",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",
-        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.54",
+        "@aws-cdk/asset-node-proxy-agent-v5": "^2.0.58",
         "@balena/dockerignore": "^1.0.2",
         "case": "1.6.3",
         "fs-extra": "^9.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@types/prettier": "2.7.2",
         "aws-cdk": "2.64.0",
         "jest": "^27.5.1",
-        "prettier": "^2.8.2",
+        "prettier": "^2.8.4",
         "ts-jest": "^27.1.4",
         "ts-node": "^10.8.1",
         "typescript": "~4.9.5"
@@ -3736,9 +3736,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
-      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -7497,9 +7497,9 @@
       "dev": true
     },
     "prettier": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
-      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "version": "2.8.4",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.4.tgz",
+      "integrity": "sha512-vIS4Rlc2FNh0BySk3Wkd6xmwxB0FpOndW5fisM5H8hsZSxU2VWVB5CWIkIjWvrHjIhxk2g3bfMKM87zNTrZddw==",
       "dev": true
     },
     "pretty-format": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.5.2",
-        "@types/node": "18.14.1",
+        "@types/node": "18.14.2",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
         "aws-cdk": "2.66.1",
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
-      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
+      "version": "18.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -5499,9 +5499,9 @@
       }
     },
     "@types/node": {
-      "version": "18.14.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
-      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
+      "version": "18.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.64.0",
-        "axios": "^1.3.2",
+        "axios": "^1.3.3",
         "constructs": "^10.1.250",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
@@ -1470,9 +1470,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
-      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
+      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5779,9 +5779,9 @@
       }
     },
     "axios": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
-      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
+      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "10.17.27",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
-        "aws-cdk": "2.63.2",
+        "aws-cdk": "2.64.0",
         "jest": "^27.5.1",
         "prettier": "^2.8.2",
         "ts-jest": "^27.1.4",
@@ -1268,9 +1268,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.63.2.tgz",
-      "integrity": "sha512-YtWfPTOiq+cgSIiM2IwjickvJgD1ESBWzK+0+yeauC3XwdaVcfNeTHF3sEqmc5DRMPKV8kAVBBxc0fmuoxcnBQ==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
+      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -5654,9 +5654,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-cdk": {
-      "version": "2.63.2",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.63.2.tgz",
-      "integrity": "sha512-YtWfPTOiq+cgSIiM2IwjickvJgD1ESBWzK+0+yeauC3XwdaVcfNeTHF3sEqmc5DRMPKV8kAVBBxc0fmuoxcnBQ==",
+      "version": "2.64.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
+      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "finch-aws-cdk",
       "version": "0.1.0",
       "dependencies": {
-        "aws-cdk-lib": "2.66.0",
+        "aws-cdk-lib": "2.66.1",
         "axios": "^1.3.4",
         "constructs": "^10.1.262",
         "node-fetch": "^2.6.7",
@@ -1283,9 +1283,9 @@
       }
     },
     "node_modules/aws-cdk-lib": {
-      "version": "2.66.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.66.0.tgz",
-      "integrity": "sha512-Qmw+lB8uFO+wJX8czw05ciUJObB5gJ5euOXYXXC9BuFPMy1WTA+HYqgSRvgv2mIEnjQb1zlG05oNalvH24Ha7Q==",
+      "version": "2.66.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.66.1.tgz",
+      "integrity": "sha512-xMnKXOnsoJLoDyl6L3BUYLPa9bqw8UoBlFGGH4gbzpBPViv9b49xvYuW+BLf7bK7IVgTzYQ+VmZKaFsj+VFouA==",
       "bundleDependencies": [
         "@balena/dockerignore",
         "case",
@@ -5663,9 +5663,9 @@
       }
     },
     "aws-cdk-lib": {
-      "version": "2.66.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.66.0.tgz",
-      "integrity": "sha512-Qmw+lB8uFO+wJX8czw05ciUJObB5gJ5euOXYXXC9BuFPMy1WTA+HYqgSRvgv2mIEnjQb1zlG05oNalvH24Ha7Q==",
+      "version": "2.66.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk-lib/-/aws-cdk-lib-2.66.1.tgz",
+      "integrity": "sha512-xMnKXOnsoJLoDyl6L3BUYLPa9bqw8UoBlFGGH4gbzpBPViv9b49xvYuW+BLf7bK7IVgTzYQ+VmZKaFsj+VFouA==",
       "requires": {
         "@aws-cdk/asset-awscli-v1": "^2.2.69",
         "@aws-cdk/asset-kubectl-v20": "^2.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.5.2",
-        "@types/node": "10.17.27",
+        "@types/node": "18.13.0",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
         "aws-cdk": "2.64.0",
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "10.17.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
-      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -5499,9 +5499,9 @@
       }
     },
     "@types/node": {
-      "version": "10.17.27",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.27.tgz",
-      "integrity": "sha512-J0oqm9ZfAXaPdwNXMMgAhylw5fhmXkToJd06vuDUSAgEDZ/n/69/69UmyBZbc+zT34UnShuDSBqvim3SPnozJg==",
+      "version": "18.13.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.13.0.tgz",
+      "integrity": "sha512-gC3TazRzGoOnoKAhUx+Q0t8S9Tzs74z7m0ipwGpSqQrleP14hKxP4/JUeEQcD3W1/aIpnWl8pHowI7WokuZpXg==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "18.14.1",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
-        "aws-cdk": "2.66.0",
+        "aws-cdk": "2.66.1",
         "jest": "^27.5.1",
         "prettier": "^2.8.4",
         "ts-jest": "^27.1.4",
@@ -1268,9 +1268,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.66.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.66.0.tgz",
-      "integrity": "sha512-UQ2NJsL+j1I8N0/rabORBC74Q84vZD+wK5K8tfX7a7hwCqqmon7TJ7c3lUsQgVGpbi66grcrDxmm4dXeB6cb0w==",
+      "version": "2.66.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.66.1.tgz",
+      "integrity": "sha512-exm97/VOH6yZPN2is3UC0acc6KF56AANvCg2gAEhyu6dPBueKxNCzrvsjNg/vmXrA8HqJ2jYJMg88YRNaUfylA==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -5654,9 +5654,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-cdk": {
-      "version": "2.66.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.66.0.tgz",
-      "integrity": "sha512-UQ2NJsL+j1I8N0/rabORBC74Q84vZD+wK5K8tfX7a7hwCqqmon7TJ7c3lUsQgVGpbi66grcrDxmm4dXeB6cb0w==",
+      "version": "2.66.1",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.66.1.tgz",
+      "integrity": "sha512-exm97/VOH6yZPN2is3UC0acc6KF56AANvCg2gAEhyu6dPBueKxNCzrvsjNg/vmXrA8HqJ2jYJMg88YRNaUfylA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "2.66.1",
         "axios": "^1.3.4",
-        "constructs": "^10.1.262",
+        "constructs": "^10.1.263",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
       },
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.262",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.262.tgz",
-      "integrity": "sha512-gVK1wapBFr2PhLz+b45n1WcpG3R7O4zFKyEiJnVLobFxCfmY8Gc3p8qyZZ7E8d6j5HMo9c7oFQmfLA8BVNm27g==",
+      "version": "10.1.263",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.263.tgz",
+      "integrity": "sha512-lJq4n2iukIQE/XtSfMMwnOE33n67kSzNi6rF3C83RrHYtrQYRswOcAv3XJciCQoznxn99pKmgsxAQBYJlYcwFg==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -6024,9 +6024,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.262",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.262.tgz",
-      "integrity": "sha512-gVK1wapBFr2PhLz+b45n1WcpG3R7O4zFKyEiJnVLobFxCfmY8Gc3p8qyZZ7E8d6j5HMo9c7oFQmfLA8BVNm27g=="
+      "version": "10.1.263",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.263.tgz",
+      "integrity": "sha512-lJq4n2iukIQE/XtSfMMwnOE33n67kSzNi6rF3C83RrHYtrQYRswOcAv3XJciCQoznxn99pKmgsxAQBYJlYcwFg=="
     },
     "convert-source-map": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.64.0",
-        "axios": "^1.3.0",
+        "axios": "^1.3.2",
         "constructs": "^10.1.218",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
@@ -1470,9 +1470,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.0.tgz",
-      "integrity": "sha512-oCye5nHhTypzkdLIvF9SaHfr8UAquqCn1KY3j8vsrjeol8yohAdGxIpRPbF1bOLsx33HOAatdfMX1yzsj2cHwg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
+      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5779,9 +5779,9 @@
       }
     },
     "axios": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.0.tgz",
-      "integrity": "sha512-oCye5nHhTypzkdLIvF9SaHfr8UAquqCn1KY3j8vsrjeol8yohAdGxIpRPbF1bOLsx33HOAatdfMX1yzsj2cHwg==",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.2.tgz",
+      "integrity": "sha512-1M3O703bYqYuPhbHeya5bnhpYVsDDRyQSabNja04mZtboLNSuZ4YrltestrLXfHgmzua4TpUqRiVKbiQuo2epw==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "2.65.0",
         "axios": "^1.3.3",
-        "constructs": "^10.1.250",
+        "constructs": "^10.1.256",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
       },
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.250",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.250.tgz",
-      "integrity": "sha512-eF71tcgvo6jMO/NlPFWuUpJ0VrpA9kvRvusIFLPjfV6h75epVQPwyhPoVlS0hHFQsujQJNXMLltaeRZSGhILcw==",
+      "version": "10.1.256",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.256.tgz",
+      "integrity": "sha512-R9mPHqGo+Y2mkaBeQc2+fTC3SZgr8a39tpy3hXT70yvpbxSrTcqPqukksm7ZltDDr2osLjv5Xwt5x/SqjHtATw==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -6024,9 +6024,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.250",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.250.tgz",
-      "integrity": "sha512-eF71tcgvo6jMO/NlPFWuUpJ0VrpA9kvRvusIFLPjfV6h75epVQPwyhPoVlS0hHFQsujQJNXMLltaeRZSGhILcw=="
+      "version": "10.1.256",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.256.tgz",
+      "integrity": "sha512-R9mPHqGo+Y2mkaBeQc2+fTC3SZgr8a39tpy3hXT70yvpbxSrTcqPqukksm7ZltDDr2osLjv5Xwt5x/SqjHtATw=="
     },
     "convert-source-map": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "2.66.0",
         "axios": "^1.3.4",
-        "constructs": "^10.1.256",
+        "constructs": "^10.1.260",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
       },
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.256",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.256.tgz",
-      "integrity": "sha512-R9mPHqGo+Y2mkaBeQc2+fTC3SZgr8a39tpy3hXT70yvpbxSrTcqPqukksm7ZltDDr2osLjv5Xwt5x/SqjHtATw==",
+      "version": "10.1.260",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.260.tgz",
+      "integrity": "sha512-eO4BX6XkyHiPf8zQ2/seM2T9+0x2P4MlvsEPs+R2YX/hXfoAGSSRZVTW+qzlTJey31MhWyVbJ8Yx6Sja/5wNVA==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -6024,9 +6024,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.256",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.256.tgz",
-      "integrity": "sha512-R9mPHqGo+Y2mkaBeQc2+fTC3SZgr8a39tpy3hXT70yvpbxSrTcqPqukksm7ZltDDr2osLjv5Xwt5x/SqjHtATw=="
+      "version": "10.1.260",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.260.tgz",
+      "integrity": "sha512-eO4BX6XkyHiPf8zQ2/seM2T9+0x2P4MlvsEPs+R2YX/hXfoAGSSRZVTW+qzlTJey31MhWyVbJ8Yx6Sja/5wNVA=="
     },
     "convert-source-map": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "18.13.0",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
-        "aws-cdk": "2.64.0",
+        "aws-cdk": "2.65.0",
         "jest": "^27.5.1",
         "prettier": "^2.8.4",
         "ts-jest": "^27.1.4",
@@ -1268,9 +1268,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.65.0.tgz",
+      "integrity": "sha512-a1xtdf95N7MLPcwCs+IkE6kCD1utLMuDh+1RIyYbX7SYzAjlNJzOXQ7M16kBktt4KflVWseZnYsGbKWJ2DraMw==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -5654,9 +5654,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-cdk": {
-      "version": "2.64.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.64.0.tgz",
-      "integrity": "sha512-iXkvVeYKt6Glboeicrb3QxC6K6o25+zitM/UTfgVzDlKEvC4hwQp1KqXy/caN7SfA6X2N0LJmXfC99T4cvIH0A==",
+      "version": "2.65.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.65.0.tgz",
+      "integrity": "sha512-a1xtdf95N7MLPcwCs+IkE6kCD1utLMuDh+1RIyYbX7SYzAjlNJzOXQ7M16kBktt4KflVWseZnYsGbKWJ2DraMw==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "aws-cdk-lib": "2.66.0",
-        "axios": "^1.3.3",
+        "axios": "^1.3.4",
         "constructs": "^10.1.256",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
@@ -1470,9 +1470,9 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "dependencies": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",
@@ -5779,9 +5779,9 @@
       }
     },
     "axios": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.3.tgz",
-      "integrity": "sha512-eYq77dYIFS77AQlhzEL937yUBSepBfPIe8FcgEDN35vMNZKMrs81pgnyrQpwfy4NF4b4XWX1Zgx7yX+25w8QJA==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.3.4.tgz",
+      "integrity": "sha512-toYm+Bsyl6VC5wSkfkbbNB6ROv7KY93PEBBL6xyDczaIHasAiv4wPqQ/c4RjoQzipxRD2W5g21cOqQulZ7rHwQ==",
       "requires": {
         "follow-redirects": "^1.15.0",
         "form-data": "^4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/node": "18.14.1",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
-        "aws-cdk": "2.65.0",
+        "aws-cdk": "2.66.0",
         "jest": "^27.5.1",
         "prettier": "^2.8.4",
         "ts-jest": "^27.1.4",
@@ -1268,9 +1268,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.65.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.65.0.tgz",
-      "integrity": "sha512-a1xtdf95N7MLPcwCs+IkE6kCD1utLMuDh+1RIyYbX7SYzAjlNJzOXQ7M16kBktt4KflVWseZnYsGbKWJ2DraMw==",
+      "version": "2.66.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.66.0.tgz",
+      "integrity": "sha512-UQ2NJsL+j1I8N0/rabORBC74Q84vZD+wK5K8tfX7a7hwCqqmon7TJ7c3lUsQgVGpbi66grcrDxmm4dXeB6cb0w==",
       "dev": true,
       "bin": {
         "cdk": "bin/cdk"
@@ -5654,9 +5654,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-cdk": {
-      "version": "2.65.0",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.65.0.tgz",
-      "integrity": "sha512-a1xtdf95N7MLPcwCs+IkE6kCD1utLMuDh+1RIyYbX7SYzAjlNJzOXQ7M16kBktt4KflVWseZnYsGbKWJ2DraMw==",
+      "version": "2.66.0",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.66.0.tgz",
+      "integrity": "sha512-UQ2NJsL+j1I8N0/rabORBC74Q84vZD+wK5K8tfX7a7hwCqqmon7TJ7c3lUsQgVGpbi66grcrDxmm4dXeB6cb0w==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "2.66.1",
         "axios": "^1.3.4",
-        "constructs": "^10.1.263",
+        "constructs": "^10.1.264",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
       },
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.263",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.263.tgz",
-      "integrity": "sha512-lJq4n2iukIQE/XtSfMMwnOE33n67kSzNi6rF3C83RrHYtrQYRswOcAv3XJciCQoznxn99pKmgsxAQBYJlYcwFg==",
+      "version": "10.1.264",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.264.tgz",
+      "integrity": "sha512-f9db+zgEV9xiIhmHxBuxNU2DjmnIQkM5M4IyLvjP+pBtS3r+PflQFwdZlDuy3K84NMnSaI4J/Sz5i5aNgwmDAg==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -6024,9 +6024,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.263",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.263.tgz",
-      "integrity": "sha512-lJq4n2iukIQE/XtSfMMwnOE33n67kSzNi6rF3C83RrHYtrQYRswOcAv3XJciCQoznxn99pKmgsxAQBYJlYcwFg=="
+      "version": "10.1.264",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.264.tgz",
+      "integrity": "sha512-f9db+zgEV9xiIhmHxBuxNU2DjmnIQkM5M4IyLvjP+pBtS3r+PflQFwdZlDuy3K84NMnSaI4J/Sz5i5aNgwmDAg=="
     },
     "convert-source-map": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "2.64.0",
         "axios": "^1.3.2",
-        "constructs": "^10.1.218",
+        "constructs": "^10.1.250",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
       },
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.218",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.218.tgz",
-      "integrity": "sha512-XTRRbPHw9wyTrRZ5j9OE61KgoW9B3gBkcVJz+FB9qH4xnXh94rJzoipcaCzTMMdtWe/LLGLEsjx25rOld9tosA==",
+      "version": "10.1.250",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.250.tgz",
+      "integrity": "sha512-eF71tcgvo6jMO/NlPFWuUpJ0VrpA9kvRvusIFLPjfV6h75epVQPwyhPoVlS0hHFQsujQJNXMLltaeRZSGhILcw==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -6024,9 +6024,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.218",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.218.tgz",
-      "integrity": "sha512-XTRRbPHw9wyTrRZ5j9OE61KgoW9B3gBkcVJz+FB9qH4xnXh94rJzoipcaCzTMMdtWe/LLGLEsjx25rOld9tosA=="
+      "version": "10.1.250",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.250.tgz",
+      "integrity": "sha512-eF71tcgvo6jMO/NlPFWuUpJ0VrpA9kvRvusIFLPjfV6h75epVQPwyhPoVlS0hHFQsujQJNXMLltaeRZSGhILcw=="
     },
     "convert-source-map": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "aws-cdk-lib": "2.66.0",
         "axios": "^1.3.4",
-        "constructs": "^10.1.260",
+        "constructs": "^10.1.262",
         "node-fetch": "^2.6.7",
         "source-map-support": "^0.5.21"
       },
@@ -1793,9 +1793,9 @@
       "dev": true
     },
     "node_modules/constructs": {
-      "version": "10.1.260",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.260.tgz",
-      "integrity": "sha512-eO4BX6XkyHiPf8zQ2/seM2T9+0x2P4MlvsEPs+R2YX/hXfoAGSSRZVTW+qzlTJey31MhWyVbJ8Yx6Sja/5wNVA==",
+      "version": "10.1.262",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.262.tgz",
+      "integrity": "sha512-gVK1wapBFr2PhLz+b45n1WcpG3R7O4zFKyEiJnVLobFxCfmY8Gc3p8qyZZ7E8d6j5HMo9c7oFQmfLA8BVNm27g==",
       "engines": {
         "node": ">= 14.17.0"
       }
@@ -6024,9 +6024,9 @@
       "dev": true
     },
     "constructs": {
-      "version": "10.1.260",
-      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.260.tgz",
-      "integrity": "sha512-eO4BX6XkyHiPf8zQ2/seM2T9+0x2P4MlvsEPs+R2YX/hXfoAGSSRZVTW+qzlTJey31MhWyVbJ8Yx6Sja/5wNVA=="
+      "version": "10.1.262",
+      "resolved": "https://registry.npmjs.org/constructs/-/constructs-10.1.262.tgz",
+      "integrity": "sha512-gVK1wapBFr2PhLz+b45n1WcpG3R7O4zFKyEiJnVLobFxCfmY8Gc3p8qyZZ7E8d6j5HMo9c7oFQmfLA8BVNm27g=="
     },
     "convert-source-map": {
       "version": "1.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
       },
       "devDependencies": {
         "@types/jest": "^27.5.2",
-        "@types/node": "18.14.0",
+        "@types/node": "18.14.1",
         "@types/node-fetch": "^2.6.2",
         "@types/prettier": "2.7.2",
         "aws-cdk": "2.65.0",
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "version": "18.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
+      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
       "dev": true
     },
     "node_modules/@types/node-fetch": {
@@ -5499,9 +5499,9 @@
       }
     },
     "@types/node": {
-      "version": "18.14.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.0.tgz",
-      "integrity": "sha512-5EWrvLmglK+imbCJY0+INViFWUHg1AHel1sq4ZVSfdcNqGy9Edv3UB9IIzzg+xPaUcAgZYcfVs2fBcwDeZzU0A==",
+      "version": "18.14.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.1.tgz",
+      "integrity": "sha512-QH+37Qds3E0eDlReeboBxfHbX9omAcBCXEzswCu6jySP642jiM3cYSIkU/REqwhCUqXdonHFuBfJDiAJxMNhaQ==",
       "dev": true
     },
     "@types/node-fetch": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "18.13.0",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
-    "aws-cdk": "2.64.0",
+    "aws-cdk": "2.65.0",
     "jest": "^27.5.1",
     "prettier": "^2.8.4",
     "ts-jest": "^27.1.4",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",
-    "@types/node": "18.14.0",
+    "@types/node": "18.14.1",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
     "aws-cdk": "2.65.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-cdk-lib": "2.64.0",
     "axios": "^1.3.2",
-    "constructs": "^10.1.218",
+    "constructs": "^10.1.250",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.64.0",
-    "axios": "^1.3.0",
+    "axios": "^1.3.2",
     "constructs": "^10.1.218",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.64.0",
-    "axios": "^1.3.2",
+    "axios": "^1.3.3",
     "constructs": "^10.1.250",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "18.14.1",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
-    "aws-cdk": "2.66.0",
+    "aws-cdk": "2.66.1",
     "jest": "^27.5.1",
     "prettier": "^2.8.4",
     "ts-jest": "^27.1.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.66.0",
+    "aws-cdk-lib": "2.66.1",
     "axios": "^1.3.4",
     "constructs": "^10.1.262",
     "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-cdk-lib": "2.65.0",
     "axios": "^1.3.3",
-    "constructs": "^10.1.250",
+    "constructs": "^10.1.256",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"
   }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.62.2",
+    "aws-cdk-lib": "2.64.0",
     "axios": "^1.3.0",
     "constructs": "^10.1.218",
     "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",
-    "@types/node": "10.17.27",
+    "@types/node": "18.13.0",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
     "aws-cdk": "2.64.0",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",
-    "@types/node": "18.13.0",
+    "@types/node": "18.14.0",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
     "aws-cdk": "2.65.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-cdk-lib": "2.66.0",
     "axios": "^1.3.4",
-    "constructs": "^10.1.256",
+    "constructs": "^10.1.260",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "18.14.1",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
-    "aws-cdk": "2.65.0",
+    "aws-cdk": "2.66.0",
     "jest": "^27.5.1",
     "prettier": "^2.8.4",
     "ts-jest": "^27.1.4",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-cdk-lib": "2.66.1",
     "axios": "^1.3.4",
-    "constructs": "^10.1.262",
+    "constructs": "^10.1.263",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"
   }

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "aws-cdk-lib": "2.66.0",
-    "axios": "^1.3.3",
+    "axios": "^1.3.4",
     "constructs": "^10.1.256",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "@types/jest": "^27.5.2",
-    "@types/node": "18.14.1",
+    "@types/node": "18.14.2",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
     "aws-cdk": "2.66.1",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-cdk-lib": "2.66.1",
     "axios": "^1.3.4",
-    "constructs": "^10.1.263",
+    "constructs": "^10.1.264",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"
   }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "aws-cdk-lib": "2.66.0",
     "axios": "^1.3.4",
-    "constructs": "^10.1.260",
+    "constructs": "^10.1.262",
     "node-fetch": "^2.6.7",
     "source-map-support": "^0.5.21"
   }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@types/prettier": "2.7.2",
     "aws-cdk": "2.64.0",
     "jest": "^27.5.1",
-    "prettier": "^2.8.2",
+    "prettier": "^2.8.4",
     "ts-jest": "^27.1.4",
     "ts-node": "^10.8.1",
     "typescript": "~4.9.5"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.65.0",
+    "aws-cdk-lib": "2.66.0",
     "axios": "^1.3.3",
     "constructs": "^10.1.256",
     "node-fetch": "^2.6.7",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/node": "10.17.27",
     "@types/node-fetch": "^2.6.2",
     "@types/prettier": "2.7.2",
-    "aws-cdk": "2.63.2",
+    "aws-cdk": "2.64.0",
     "jest": "^27.5.1",
     "prettier": "^2.8.2",
     "ts-jest": "^27.1.4",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "typescript": "~4.9.5"
   },
   "dependencies": {
-    "aws-cdk-lib": "2.64.0",
+    "aws-cdk-lib": "2.65.0",
     "axios": "^1.3.3",
     "constructs": "^10.1.250",
     "node-fetch": "^2.6.7",


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
To monitor the OS patching, The Mac Instances needs to report to PVRE. This changes will allow the Mac Instances to report the OS versions to PVRE for generating the report.

*Testing done:*
Yes. In local dev account.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
