### PR TITLE
Enable PVRE Reporting for All Mac Instances

### DIFF
--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -73,8 +73,6 @@ export class FinchPipelineAppStage extends cdk.Stage {
     this.cloudfrontBucket = artifactBucketCloudfrontStack.bucket;
 
     new ContinuousIntegrationStack(this, 'FinchContinuousIntegrationStack', this.stageName);
-    if (props?.environmentStage == ENVIRONMENT_STAGE.Beta) {
-      new PVREReportingStack(this, 'PVREReportingStack');
-    }
+    new PVREReportingStack(this, 'PVREReportingStack');
   }
 }

--- a/lib/mac-runner-stack.ts
+++ b/lib/mac-runner-stack.ts
@@ -76,9 +76,7 @@ export class MacRunnerStack extends cdk.Stack {
 
     //Add the tag for SSM PVRE reporting. This tag is used in the pvre-reporting-template.yml file. 
     // See Resources.InventoryCollection.Properties.Targets property in pvre-reporting-template.yml file.
-    if(props?.environmentStage == ENVIRONMENT_STAGE.Beta) {
-      Tags.of(macInstance).add('PVRE-Reporting', 'SSM')
-    }
+    Tags.of(macInstance).add('PVRE-Reporting', 'SSM')
 
     const cfnInstance = macInstance.node.defaultChild as ec2.CfnInstance;
     cfnInstance.addPropertyOverride('Tenancy', 'host');


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
To monitor the OS patching, The Mac Instances needs to report to PVRE. This changes will allow the Prod Mac Instances to report the OS versions to PVRE for generating the report.


*Testing done:*
Yes. In local dev account.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
