### PR TITLE
Revert "Add release account and create runner stack (#144)"

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -92,49 +92,5 @@
         ]
       }
     ]
-  },
-  "vpc-provider:account=019528120233:filter.isDefault=true:region=us-west-2:returnAsymmetricSubnets=true": {
-    "vpcId": "vpc-085eb9c9264d91f89",
-    "vpcCidrBlock": "172.31.0.0/16",
-    "availabilityZones": [],
-    "subnetGroups": [
-      {
-        "name": "Public",
-        "type": "Public",
-        "subnets": [
-          {
-            "subnetId": "subnet-0041c3b7bacac743a",
-            "cidr": "172.31.16.0/20",
-            "availabilityZone": "us-west-2a",
-            "routeTableId": "rtb-0a95dee50b2da04d2"
-          },
-          {
-            "subnetId": "subnet-0e1ee2c0233c8bf46",
-            "cidr": "172.31.32.0/20",
-            "availabilityZone": "us-west-2b",
-            "routeTableId": "rtb-0a95dee50b2da04d2"
-          },
-          {
-            "subnetId": "subnet-01ed7305856c08ddd",
-            "cidr": "172.31.0.0/20",
-            "availabilityZone": "us-west-2c",
-            "routeTableId": "rtb-0a95dee50b2da04d2"
-          },
-          {
-            "subnetId": "subnet-0085847c20357499a",
-            "cidr": "172.31.48.0/20",
-            "availabilityZone": "us-west-2d",
-            "routeTableId": "rtb-0a95dee50b2da04d2"
-          }
-        ]
-      }
-    ]
-  },
-  "ami:account=019528120233:filters.architecture.0=x86_64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-12.6*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-08fd945db833e3080",
-  "ami:account=019528120233:filters.architecture.0=arm64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-12.6*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-03c004b7678f06da9",
-  "ami:account=019528120233:filters.architecture.0=x86_64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-11.7*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-03f373d21b49ff7b9",
-  "ami:account=019528120233:filters.architecture.0=arm64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-11.7*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-049b5f71a51695359",
-  "ami:account=019528120233:filters.architecture.0=arm64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-13.0*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-05171ef395de44103",
-  "ami:account=019528120233:filters.architecture.0=x86_64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-13.0*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-0dd2ded7568750663",
-  "ami:account=019528120233:filters.architecture.0=x86_64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-10.15*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-0c831ab5db6514fb6"
+  }
 }

--- a/config/Config.ts
+++ b/config/Config.ts
@@ -9,7 +9,6 @@ class ConfigClass {
   public readonly envPipeline: envProps;
   public readonly envBeta: envProps;
   public readonly envProd: envProps;
-  public readonly envRelease: envProps;
 
   constructor(configFile: any) {
     if (!configFile.envPipeline) {
@@ -26,11 +25,6 @@ class ConfigClass {
       throw new Error('Error: envProd must be specified.');
     }
     this.envProd = configFile.envProd;
-
-    if (!configFile.envRelease) {
-      throw new Error('Error: envRelease must be specified.');
-    }
-    this.envRelease = configFile.envRelease;
   }
 }
 

--- a/config/config.json
+++ b/config/config.json
@@ -1,6 +1,5 @@
 {
     "envPipeline": {"account": "229528898709", "region":"us-west-2"},
     "envBeta": {"account": "820462304213", "region":"us-west-2"},
-    "envProd": {"account": "090529234398", "region":"us-west-2"},
-    "envRelease": {"account": "019528120233", "region": "us-west-2"}
+    "envProd": {"account": "090529234398", "region":"us-west-2"}
 }

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -9,8 +9,7 @@ import { PVREReportingStack } from './pvre-reporting-stack';
 
 export enum ENVIRONMENT_STAGE {
   Beta,
-  Prod,
-  Release
+  Prod
 }
 
 interface FinchPipelineAppStageProps extends cdk.StageProps {
@@ -41,7 +40,6 @@ export class FinchPipelineAppStage extends cdk.Stage {
     {'stackName':'macOS12amd64StackBeta', 'ver':'12.6','arch':'x86_64_mac'},
     {'stackName':'macOS12arm64StackBeta', 'ver':'12.6','arch':'arm64_mac'}
   ];
-
   private ProdRunnerStack: MacConfig[] = [
     {'stackName':'macOS12amd64Stack1', 'ver':'12.6','arch':'x86_64_mac'},
     {'stackName':'macOS12arm64Stack1', 'ver':'12.6','arch':'arm64_mac'},
@@ -57,30 +55,16 @@ export class FinchPipelineAppStage extends cdk.Stage {
     {'stackName':'macOS11arm64Stack3', 'ver':'11.7','arch':'arm64_mac'}
   ];
 
-  private ReleaseRunnerStack: MacConfig[] = [
-    {'stackName':'macOS12amd64StackRelease', 'ver':'12.6','arch':'x86_64_mac'},
-    {'stackName':'macOS12arm64StackRelease', 'ver':'12.6','arch':'arm64_mac'},
-    {'stackName':'macOS11amd64StackRelease', 'ver':'11.7','arch':'x86_64_mac'},
-    {'stackName':'macOS11arm64StackRelease', 'ver':'11.7','arch':'arm64_mac'},
-    {'stackName':'macOS13arm64StackRelease', 'ver':'13.0','arch':'arm64_mac'},
-    {'stackName':'macOS13amd64StackRelease', 'ver':'13.0','arch':'x86_64_mac'},
-    {'stackName':'macOS10amd64StackRelease', 'ver':'10.15','arch':'x86_64_mac'},
-  ]
-
-  constructor(scope: Construct, id: string, props: FinchPipelineAppStageProps) {
+  constructor(scope: Construct, id: string, props?: FinchPipelineAppStageProps) {
     super(scope, id, props);
 
-    if (props.environmentStage === ENVIRONMENT_STAGE.Beta) {
-      this.BetaRunnerStack.forEach((runner: MacConfig) => {
-       this.createMacRunnerStack(props, runner); 
+    if (props?.environmentStage == ENVIRONMENT_STAGE.Beta) {
+      this.BetaRunnerStack.forEach(element => {
+       this.createMacRunnerStack(props, element); 
       });
-    } else if (props.environmentStage === ENVIRONMENT_STAGE.Prod) {
-      this.ProdRunnerStack.forEach((runner: MacConfig) => {
-        this.createMacRunnerStack(props, runner);
-      })
     } else {
-      this.ReleaseRunnerStack.forEach((runner: MacConfig) => {
-        this.createMacRunnerStack(props, runner)
+      this.ProdRunnerStack.forEach(element => {
+        this.createMacRunnerStack(props, element);
       })
     }
 

--- a/lib/finch-pipeline-stack.ts
+++ b/lib/finch-pipeline-stack.ts
@@ -37,19 +37,11 @@ export class FinchPipelineStack extends cdk.Stack {
         }
       })
     );
-    // Add stages to a wave to deploy them in parallel.
-    const wave = pipeline.addWave("wave")
 
     const prodApp = new FinchPipelineAppStage(this, 'Production', {
       environmentStage: ENVIRONMENT_STAGE.Prod,
       env: Config.envProd
     });
-    wave.addStage(prodApp)
-
-    const releaseApp = new FinchPipelineAppStage(this, 'Release', {
-      environmentStage: ENVIRONMENT_STAGE.Release,
-      env: Config.envRelease
-    });
-    wave.addStage(releaseApp)
+    const prodStage = pipeline.addStage(prodApp);
   }
 }


### PR DESCRIPTION
This reverts [commit c3a8c25462c7556845d833bb2702e8750900f818](https://github.com/runfinch/infrastructure/commit/c3a8c25462c7556845d833bb2702e8750900f818).

*Description of changes:*

- Current release account does not have the service quota needed to start the macOS instances, so that commit is rolled back to enable the subsequent commit for enabling [PVRE monitoring](https://github.com/runfinch/infrastructure/commit/ee4995357f2bc688e1a70e585d90801858d009a5) to work.

*Testing done:*

- Ran `cdk synth` locally


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

