### PR TITLE
Updated prod stage for 4 more ventura runners

### DIFF
--- a/cdk.context.json
+++ b/cdk.context.json
@@ -92,5 +92,7 @@
         ]
       }
     ]
-  }
+  },
+  "ami:account=090529234398:filters.architecture.0=x86_64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-13.2*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-09bb28e86b754a476",
+  "ami:account=090529234398:filters.architecture.0=arm64_mac:filters.image-type.0=machine:filters.name.0=amzn-ec2-macos-13.2*:filters.owner-alias.0=amazon:filters.root-device-type.0=ebs:filters.state.0=available:filters.virtualization-type.0=hvm:region=us-west-2": "ami-0d4a16c69c1be18c7"
 }

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -52,7 +52,11 @@ export class FinchPipelineAppStage extends cdk.Stage {
     {'stackName':'macOS12amd64Stack3', 'ver':'12.6','arch':'x86_64_mac'},
     {'stackName':'macOS12arm64Stack3', 'ver':'12.6','arch':'arm64_mac'},
     {'stackName':'macOS11amd64Stack3', 'ver':'11.7','arch':'x86_64_mac'},
-    {'stackName':'macOS11arm64Stack3', 'ver':'11.7','arch':'arm64_mac'}
+    {'stackName':'macOS11arm64Stack3', 'ver':'11.7','arch':'arm64_mac'},
+    {'stackName':'macOS13amd64Stack4-1', 'ver':'13.2','arch':'x86_64_mac'},
+    {'stackName':'macOS13arm64Stack4-1', 'ver':'13.2','arch':'arm64_mac'},
+    {'stackName':'macOS13amd64Stack4-2', 'ver':'13.2','arch':'x86_64_mac'},
+    {'stackName':'macOS13arm64Stack4-2', 'ver':'13.2','arch':'arm64_mac'}
   ];
 
   constructor(scope: Construct, id: string, props?: FinchPipelineAppStageProps) {

--- a/lib/setup-amd64-runner.sh
+++ b/lib/setup-amd64-runner.sh
@@ -4,9 +4,7 @@
 HOMEDIR="/Users/ec2-user"
 RUNNER_DIR="$HOMEDIR/ar"
 mkdir -p $RUNNER_DIR && cd $RUNNER_DIR
-curl -o actions-runner-osx-x64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-osx-x64-2.298.2.tar.gz
-echo "0fb116f0d16ac75bcafa68c8db7c816f36688d3674266fe65139eefec3a9eb04  actions-runner-osx-x64-2.298.2.tar.gz" | shasum -a 256 -c
+curl -o actions-runner-osx-x64-2.302.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.302.1/actions-runner-osx-x64-2.302.1.tar.gz
+echo "cc061fc4ae62afcbfab1e18f1b2a7fc283295ca3459345f31a719d36480a8361  actions-runner-osx-x64-2.302.1.tar.gz" | shasum -a 256 -c
 # Extract the installer
-tar xzf ./actions-runner-osx-x64-2.298.2.tar.gz
-
-
+tar xzf ./actions-runner-osx-x64-2.302.1.tar.gz

--- a/lib/setup-arm64-runner.sh
+++ b/lib/setup-arm64-runner.sh
@@ -4,7 +4,7 @@
 HOMEDIR="/Users/ec2-user"
 RUNNER_DIR="$HOMEDIR/ar"
 mkdir -p $RUNNER_DIR && cd $RUNNER_DIR
-curl -o actions-runner-osx-arm64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-osx-arm64-2.298.2.tar.gz
-echo "e124418a44139b4b80a7b732cfbaee7ef5d2f10eab6bcb3fd67d5541493aa971  actions-runner-osx-arm64-2.298.2.tar.gz" | shasum -a 256 -c
+curl -o actions-runner-osx-arm64-2.302.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.302.1/actions-runner-osx-arm64-2.302.1.tar.gz
+echo "f78f4db37bb7ba80e6123cec0e3984d1f2bb3f8f3a16db679c42ef830e0981d3  actions-runner-osx-arm64-2.302.1.tar.gz" | shasum -a 256 -c
 # Extract the installer
-tar xzf ./actions-runner-osx-arm64-2.298.2.tar.gz
+tar xzf ./actions-runner-osx-arm64-2.302.1.tar.gz


### PR DESCRIPTION
*Issue #, if available:*
- https://github.com/runfinch/infrastructure/issues/40

*Description of changes:*

- Onboard four more macOS 13.2 runners to eventually replace the macOS 11.7 runners.
- Updated the runner provisioning script for the newest GH Actions app

*Testing done:*

- Ran `cdk synth` locally
- Ran `npm test` locally


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
