### PR TITLE
Revert data files to prevent mac instances restarting

### DIFF
--- a/lib/setup-amd64-runner.sh
+++ b/lib/setup-amd64-runner.sh
@@ -4,7 +4,9 @@
 HOMEDIR="/Users/ec2-user"
 RUNNER_DIR="$HOMEDIR/ar"
 mkdir -p $RUNNER_DIR && cd $RUNNER_DIR
-curl -o actions-runner-osx-x64-2.302.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.302.1/actions-runner-osx-x64-2.302.1.tar.gz
-echo "cc061fc4ae62afcbfab1e18f1b2a7fc283295ca3459345f31a719d36480a8361  actions-runner-osx-x64-2.302.1.tar.gz" | shasum -a 256 -c
+curl -o actions-runner-osx-x64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-osx-x64-2.298.2.tar.gz
+echo "0fb116f0d16ac75bcafa68c8db7c816f36688d3674266fe65139eefec3a9eb04  actions-runner-osx-x64-2.298.2.tar.gz" | shasum -a 256 -c
 # Extract the installer
-tar xzf ./actions-runner-osx-x64-2.302.1.tar.gz
+tar xzf ./actions-runner-osx-x64-2.298.2.tar.gz
+
+

--- a/lib/setup-arm64-runner.sh
+++ b/lib/setup-arm64-runner.sh
@@ -4,7 +4,7 @@
 HOMEDIR="/Users/ec2-user"
 RUNNER_DIR="$HOMEDIR/ar"
 mkdir -p $RUNNER_DIR && cd $RUNNER_DIR
-curl -o actions-runner-osx-arm64-2.302.1.tar.gz -L https://github.com/actions/runner/releases/download/v2.302.1/actions-runner-osx-arm64-2.302.1.tar.gz
-echo "f78f4db37bb7ba80e6123cec0e3984d1f2bb3f8f3a16db679c42ef830e0981d3  actions-runner-osx-arm64-2.302.1.tar.gz" | shasum -a 256 -c
+curl -o actions-runner-osx-arm64-2.298.2.tar.gz -L https://github.com/actions/runner/releases/download/v2.298.2/actions-runner-osx-arm64-2.298.2.tar.gz
+echo "e124418a44139b4b80a7b732cfbaee7ef5d2f10eab6bcb3fd67d5541493aa971  actions-runner-osx-arm64-2.298.2.tar.gz" | shasum -a 256 -c
 # Extract the installer
-tar xzf ./actions-runner-osx-arm64-2.302.1.tar.gz
+tar xzf ./actions-runner-osx-arm64-2.298.2.tar.gz


### PR DESCRIPTION
Updated GH Action runner data files for https://github.com/runfinch/infrastructure/commit/bc9ac2e20bc1592c3c73d05316a632efa51d7076 caused instances to restart and time out due to the long waiting period for macOS instances.

*Description of changes:*
- Reverted data file changes.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
