### PR TITLE
Multi Region AvailabilityZone selection of mac instances

### DIFF
--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -30,13 +30,11 @@ export class FinchPipelineAppStage extends cdk.Stage {
 
     //set the availability zone.
     var availabilityZones = this.node.tryGetContext('availabilityZones');
+    console.debug("availability zones from context: " + availabilityZones);
     //TODO: Improve the availability zone selection logic. Instead of assigning default availability zone, we can throw exception
     // when availability zone from context is empty.
-    var selectedAvailabilityZone = config.defaultAvailabilityZone;
-    if (availabilityZones?.length > 0) {
-      console.debug("availability zones from context: " + availabilityZones);
-      selectedAvailabilityZone = availabilityZones[availabilityZones.length - 1];
-    }
+    var selectedAvailabilityZone = availabilityZones?.at(-1) ?? config.defaultAvailabilityZone;
+    console.debug("selectedAvailabilityZone: " + selectedAvailabilityZone);
     new MacRunnerStack(this, config.stackName, {
       ...parentProps,
       userDataScriptPath: config.arch == 'x86_64_mac' ? './lib/setup-amd64-runner.sh' : './lib/setup-arm64-runner.sh',

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -27,10 +27,14 @@ export class FinchPipelineAppStage extends cdk.Stage {
   artifactBucketCloudfrontUrlOutput: CfnOutput;
   public readonly cloudfrontBucket: s3.Bucket;
   private createMacRunnerStack(parentProps: FinchPipelineAppStageProps | undefined, config: MacConfig): void {
+
     //set the availability zone.
     var availabilityZones = this.node.tryGetContext('availabilityZones');
+    //TODO: Improve the availability zone selection logic. Instead of assigning default availability zone, we can throw exception
+    // when availability zone from context is empty.
     var selectedAvailabilityZone = config.defaultAvailabilityZone;
     if(availabilityZones?.length > 0) {
+      console.debug("availability zones: " + availabilityZones)
       selectedAvailabilityZone = availabilityZones[availabilityZones.length-1];
     }
     new MacRunnerStack(this, config.stackName, {

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -19,17 +19,24 @@ interface FinchPipelineAppStageProps extends cdk.StageProps {
 interface MacConfig {
   stackName: string,
   ver: string,
-  arch: string
+  arch: string,
+  defaultAvailabilityZone: string,
 }
 
 export class FinchPipelineAppStage extends cdk.Stage {
   artifactBucketCloudfrontUrlOutput: CfnOutput;
   public readonly cloudfrontBucket: s3.Bucket;
   private createMacRunnerStack(parentProps: FinchPipelineAppStageProps | undefined, config: MacConfig): void {
+    //set the availability zone.
+    var availabilityZones = this.node.tryGetContext('availabilityZones');
+    var selectedAvailabilityZone = config.defaultAvailabilityZone;
+    if(availabilityZones?.length > 0) {
+      selectedAvailabilityZone = availabilityZones[availabilityZones.length-1];
+    }
     new MacRunnerStack(this, config.stackName, {
       ...parentProps,
       userDataScriptPath: config.arch == 'x86_64_mac' ? './lib/setup-amd64-runner.sh' : './lib/setup-arm64-runner.sh', 
-      availabilityZone: this.node.tryGetContext('availabilityZones')?.[3] ?? 'us-west-2d',
+      availabilityZone: selectedAvailabilityZone,
       macOSVersion: config.ver,
       hostType: config.arch == 'x86_64_mac' ? 'mac1.metal' : 'mac2.metal',
       architecture: config.arch,
@@ -37,26 +44,22 @@ export class FinchPipelineAppStage extends cdk.Stage {
   }
 
   private BetaRunnerStack: MacConfig[] = [
-    {'stackName':'macOS12amd64StackBeta', 'ver':'12.6','arch':'x86_64_mac'},
-    {'stackName':'macOS12arm64StackBeta', 'ver':'12.6','arch':'arm64_mac'}
+    {'stackName':'macOS12amd64StackBeta', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS12arm64StackBeta', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'}
   ];
   private ProdRunnerStack: MacConfig[] = [
-    {'stackName':'macOS12amd64Stack1', 'ver':'12.6','arch':'x86_64_mac'},
-    {'stackName':'macOS12arm64Stack1', 'ver':'12.6','arch':'arm64_mac'},
-    {'stackName':'macOS11amd64Stack1', 'ver':'11.7','arch':'x86_64_mac'},
-    {'stackName':'macOS11arm64Stack1', 'ver':'11.7','arch':'arm64_mac'},
-    {'stackName':'macOS12amd64Stack2', 'ver':'12.6','arch':'x86_64_mac'},
-    {'stackName':'macOS12arm64Stack2', 'ver':'12.6','arch':'arm64_mac'},
-    {'stackName':'macOS11amd64Stack2', 'ver':'11.7','arch':'x86_64_mac'},
-    {'stackName':'macOS11arm64Stack2', 'ver':'11.7','arch':'arm64_mac'},
-    {'stackName':'macOS12amd64Stack3', 'ver':'12.6','arch':'x86_64_mac'},
-    {'stackName':'macOS12arm64Stack3', 'ver':'12.6','arch':'arm64_mac'},
-    {'stackName':'macOS11amd64Stack3', 'ver':'11.7','arch':'x86_64_mac'},
-    {'stackName':'macOS11arm64Stack3', 'ver':'11.7','arch':'arm64_mac'},
-    {'stackName':'macOS13amd64Stack4-1', 'ver':'13.2','arch':'x86_64_mac'},
-    {'stackName':'macOS13arm64Stack4-1', 'ver':'13.2','arch':'arm64_mac'},
-    {'stackName':'macOS13amd64Stack4-2', 'ver':'13.2','arch':'x86_64_mac'},
-    {'stackName':'macOS13arm64Stack4-2', 'ver':'13.2','arch':'arm64_mac'}
+    {'stackName':'macOS12amd64Stack1', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS12arm64Stack1', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS11amd64Stack1', 'ver':'11.7','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS11arm64Stack1', 'ver':'11.7','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS12amd64Stack2', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS12arm64Stack2', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS11amd64Stack2', 'ver':'11.7','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS11arm64Stack2', 'ver':'11.7','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS12amd64Stack3', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS12arm64Stack3', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS11amd64Stack3', 'ver':'11.7','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
+    {'stackName':'macOS11arm64Stack3', 'ver':'11.7','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'}
   ];
 
   constructor(scope: Construct, id: string, props?: FinchPipelineAppStageProps) {

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -33,37 +33,37 @@ export class FinchPipelineAppStage extends cdk.Stage {
     //TODO: Improve the availability zone selection logic. Instead of assigning default availability zone, we can throw exception
     // when availability zone from context is empty.
     var selectedAvailabilityZone = config.defaultAvailabilityZone;
-    if(availabilityZones?.length > 0) {
-      console.debug("availability zones: " + availabilityZones)
-      selectedAvailabilityZone = availabilityZones[availabilityZones.length-1];
+    if (availabilityZones?.length > 0) {
+      console.debug("availability zones from context: " + availabilityZones);
+      selectedAvailabilityZone = availabilityZones[availabilityZones.length - 1];
     }
     new MacRunnerStack(this, config.stackName, {
       ...parentProps,
-      userDataScriptPath: config.arch == 'x86_64_mac' ? './lib/setup-amd64-runner.sh' : './lib/setup-arm64-runner.sh', 
+      userDataScriptPath: config.arch == 'x86_64_mac' ? './lib/setup-amd64-runner.sh' : './lib/setup-arm64-runner.sh',
       availabilityZone: selectedAvailabilityZone,
       macOSVersion: config.ver,
       hostType: config.arch == 'x86_64_mac' ? 'mac1.metal' : 'mac2.metal',
       architecture: config.arch,
-    }); 
+    });
   }
 
   private BetaRunnerStack: MacConfig[] = [
-    {'stackName':'macOS12amd64StackBeta', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS12arm64StackBeta', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'}
+    { 'stackName': 'macOS12amd64StackBeta', 'ver': '12.6', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS12arm64StackBeta', 'ver': '12.6', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' }
   ];
   private ProdRunnerStack: MacConfig[] = [
-    {'stackName':'macOS12amd64Stack1', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS12arm64Stack1', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS11amd64Stack1', 'ver':'11.7','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS11arm64Stack1', 'ver':'11.7','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS12amd64Stack2', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS12arm64Stack2', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS11amd64Stack2', 'ver':'11.7','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS11arm64Stack2', 'ver':'11.7','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS12amd64Stack3', 'ver':'12.6','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS12arm64Stack3', 'ver':'12.6','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS11amd64Stack3', 'ver':'11.7','arch':'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d'},
-    {'stackName':'macOS11arm64Stack3', 'ver':'11.7','arch':'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d'}
+    { 'stackName': 'macOS12amd64Stack1', 'ver': '12.6', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS12arm64Stack1', 'ver': '12.6', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS11amd64Stack1', 'ver': '11.7', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS11arm64Stack1', 'ver': '11.7', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS12amd64Stack2', 'ver': '12.6', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS12arm64Stack2', 'ver': '12.6', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS11amd64Stack2', 'ver': '11.7', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS11arm64Stack2', 'ver': '11.7', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS12amd64Stack3', 'ver': '12.6', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS12arm64Stack3', 'ver': '12.6', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS11amd64Stack3', 'ver': '11.7', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS11arm64Stack3', 'ver': '11.7', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' }
   ];
 
   constructor(scope: Construct, id: string, props?: FinchPipelineAppStageProps) {
@@ -71,7 +71,7 @@ export class FinchPipelineAppStage extends cdk.Stage {
 
     if (props?.environmentStage == ENVIRONMENT_STAGE.Beta) {
       this.BetaRunnerStack.forEach(element => {
-       this.createMacRunnerStack(props, element); 
+        this.createMacRunnerStack(props, element);
       });
     } else {
       this.ProdRunnerStack.forEach(element => {

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -28,12 +28,12 @@ export class FinchPipelineAppStage extends cdk.Stage {
   public readonly cloudfrontBucket: s3.Bucket;
   private createMacRunnerStack(parentProps: FinchPipelineAppStageProps | undefined, config: MacConfig): void {
 
-    //set the availability zone.
-    var availabilityZones = this.node.tryGetContext('availabilityZones');
+    // set the availability zone.
+    const availabilityZones = this.node.tryGetContext('availabilityZones');
     console.debug("availability zones from context: " + availabilityZones);
-    //TODO: Improve the availability zone selection logic. Instead of assigning default availability zone, we can throw exception
+    // TODO: Improve the availability zone selection logic. Instead of assigning default availability zone, we can throw exception
     // when availability zone from context is empty.
-    var selectedAvailabilityZone = availabilityZones?.at(-1) ?? config.defaultAvailabilityZone;
+    const selectedAvailabilityZone = availabilityZones?.at(-1) ?? config.defaultAvailabilityZone;
     console.debug("selectedAvailabilityZone: " + selectedAvailabilityZone);
     new MacRunnerStack(this, config.stackName, {
       ...parentProps,


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Previously, the default value of availability zone was hardcoded to `west-us2`. This was preventing us to deploy mac instances for other regions such as `east-us2` for release infra. To support multi region, this PR made two changes:
1. Instead of hardcoding the default availability zone to `west-us2`, now we can pass it as part of mac config parameter for each instance.
2. To select the availability zone from the cdk context, previously it used to select the 4th elements from the availabilityzone list. But not all region has 4 or more availability zone. To fix this this PR selects the last availability zone from the list instead.

*Testing done:*
I have tested this code by running `cdk synth` in local computer.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
