### PR TITLE
Add prod ventura instances again

### DIFF
--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -61,7 +61,11 @@ export class FinchPipelineAppStage extends cdk.Stage {
     { 'stackName': 'macOS12amd64Stack3', 'ver': '12.6', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
     { 'stackName': 'macOS12arm64Stack3', 'ver': '12.6', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
     { 'stackName': 'macOS11amd64Stack3', 'ver': '11.7', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
-    { 'stackName': 'macOS11arm64Stack3', 'ver': '11.7', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' }
+    { 'stackName': 'macOS11arm64Stack3', 'ver': '11.7', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS13amd64Stack4-1', 'ver': '13.2', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS13arm64Stack4-1', 'ver': '13.2', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS13amd64Stack4-2', 'ver': '13.2', 'arch': 'x86_64_mac', 'defaultAvailabilityZone': 'us-west-2d' },
+    { 'stackName': 'macOS13arm64Stack4-2', 'ver': '13.2', 'arch': 'arm64_mac', 'defaultAvailabilityZone': 'us-west-2d' }
   ];
 
   constructor(scope: Construct, id: string, props?: FinchPipelineAppStageProps) {


### PR DESCRIPTION
*Description of changes:*

macOS 13 instances were removed from the pipeline in https://github.com/runfinch/infrastructure/pull/182, this PR adds them back.

*Testing done:*

Ran cdk synth and npm test.

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
