### PR TITLE
fix: brew path

### DIFF
--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -19,7 +19,6 @@ else
   HOMEBREW_PREFIX="/usr/local"
 fi
 (echo; echo 'eval "$('"${HOMEBREW_PREFIX}"'/bin/brew shellenv)"') >> $HOME/.zshenv
-# (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> $HOME/.zshenv
 
 # Setup current shell
 PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -11,7 +11,15 @@ mkdir -p $RUNNER_DIR && cd $RUNNER_DIR
 
 # Configure brew path
 # Adding to .zshenv so that it will load even in non-interactive/login shells
-(echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/ec2-user/.zshenv
+UNAME_MACHINE="$(/usr/bin/uname -m)"
+if [[ "${UNAME_MACHINE}" == "arm64" ]]
+then
+  HOMEBREW_PREFIX="/opt/homebrew"
+else
+  HOMEBREW_PREFIX="/usr/local"
+fi
+(echo; echo 'eval "$('"${HOMEBREW_PREFIX}"'/bin/brew shellenv)"') >> $HOME/.zshenv
+# (echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> $HOME/.zshenv
 
 # Setup current shell
 PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -8,6 +8,12 @@ echo $0
 HOMEDIR="/Users/ec2-user"
 RUNNER_DIR="$HOMEDIR/ar"
 mkdir -p $RUNNER_DIR && cd $RUNNER_DIR
+
+# Configure brew path
+# Adding to .zshenv so that it will load even in non-interactive/login shells
+(echo; echo 'eval "$(/opt/homebrew/bin/brew shellenv)"') >> /Users/ec2-user/.zshenv
+
+# Setup current shell
 PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
 
 # Download and setup the runner


### PR DESCRIPTION
*Issue #, if available:* [runfinch/finch #395](https://github.com/runfinch/finch/pull/395)

*Description of changes:*
- Add brew path to `/Users/ec2-user/.zshenv`
  - The current mechanism of configuring brew is done in ~/.zshrc by default. ~/.zshrc only gets loaded in interactive sessions. CI does not run in an interactive session, hence the `brew not found` errors we're seeing in CI. On amd64 macs, the install path of brew is in a standard location, but on amd64 (M1) macs, this isn't the case. `~/.zshenv` is always loaded, so `brew` should be in `PATH` when CI runs.

*Testing done:*
- locally modified `~/.zshenv` on some CI hosts


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
