### PR TITLE
ci: Change finch-core release runner from os 12 to 13

### DIFF
--- a/config/runner-config.json
+++ b/config/runner-config.json
@@ -125,14 +125,14 @@
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
             },
             {
-                "macOSVersion": "12.6",
+                "macOSVersion": "13.2",
                 "arch": "arm",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "12.6",
+                "macOSVersion": "13.2",
                 "arch": "x86",
                 "repo": "finch-core",
                 "desiredInstances": 1,


### PR DESCRIPTION
*Description of changes:*
macOS 12 default xcode version doesn't meet the requirement to build nerdctl. Update release runner to macOS 13 for nerdctl build, while preserve macOS 11 to support other executables collection.

*Testing done:*

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
