### PR TITLE
Update instance updatepolicy

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -170,7 +170,20 @@ export class ASGRunnerStack extends cdk.Stack {
         grace: cdk.Duration.seconds(3600)
       }),
       launchTemplate: lt,
-      updatePolicy: UpdatePolicy.rollingUpdate()
+      updatePolicy: UpdatePolicy.rollingUpdate({
+        // Defaults shown here explicitly except for pauseTime
+        // and minSuccesPercentage
+        maxBatchSize: 1,
+        minInstancesInService: 0,
+        suspendProcesses: [
+          autoscaling.ScalingProcess.HEALTH_CHECK,
+          autoscaling.ScalingProcess.REPLACE_UNHEALTHY,
+          autoscaling.ScalingProcess.AZ_REBALANCE,
+          autoscaling.ScalingProcess.ALARM_NOTIFICATION,
+          autoscaling.ScalingProcess.SCHEDULED_ACTIONS,
+        ],
+        waitOnResourceSignals: true,
+      })
     });
 
     if (props.stage === ENVIRONMENT_STAGE.Beta) {

--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -7,6 +7,7 @@ import { Construct } from 'constructs';
 import { RunnerType } from '../config/runner-config';
 import { readFileSync } from 'fs';
 import { ENVIRONMENT_STAGE } from './finch-pipeline-app-stage';
+import { UpdatePolicy } from 'aws-cdk-lib/aws-autoscaling';
 
 interface ASGRunnerStackProps extends cdk.StackProps {
   env: cdk.Environment | undefined;
@@ -168,7 +169,8 @@ export class ASGRunnerStack extends cdk.Stack {
       healthCheck: autoscaling.HealthCheck.ec2({
         grace: cdk.Duration.seconds(3600)
       }),
-      launchTemplate: lt
+      launchTemplate: lt,
+      updatePolicy: UpdatePolicy.rollingUpdate()
     });
 
     if (props.stage === ENVIRONMENT_STAGE.Beta) {


### PR DESCRIPTION
Updated the updatepolicy on our ASGs so that when the following operations are performed, the instances are refreshed automatically.

- Change the Auto Scaling group's [AWS::AutoScaling::LaunchConfiguration](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-as-launchconfig.html).
- Change the Auto Scaling group's VPCZoneIdentifier property.
- Change the Auto Scaling group's LaunchTemplate property.
- Update an Auto Scaling group that contains instances that don't match the current LaunchConfiguration.


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
