### PR TITLE
fix: use $HOMEDIR instead of $HOME

### DIFF
--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -18,7 +18,7 @@ then
 else
   HOMEBREW_PREFIX="/usr/local"
 fi
-(echo; echo 'eval "$('"${HOMEBREW_PREFIX}"'/bin/brew shellenv)"') >> $HOME/.zshenv
+(echo; echo 'eval "$('"${HOMEBREW_PREFIX}"'/bin/brew shellenv)"') >> $HOMEDIR/.zshenv
 
 # Setup current shell
 PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"


### PR DESCRIPTION
*Issue #, if available:*
Tests / installer generation workflows failed on M1 after the fleet got refreshed. Checks the instance logs, and it looks like its because whatever user runs the setup script has `$HOME` set to "". Using `$HOMEDIR` instead should fix the issue. Will trigger and require redeployment to fix.

*Description of changes:*


*Testing done:*
- Manually re-configured `.zshenv` on one host.


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
