### PR TITLE
fix: remove wait on resource signal on updates

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -182,7 +182,7 @@ export class ASGRunnerStack extends cdk.Stack {
           autoscaling.ScalingProcess.ALARM_NOTIFICATION,
           autoscaling.ScalingProcess.SCHEDULED_ACTIONS,
         ],
-        waitOnResourceSignals: true,
+        waitOnResourceSignals: false,
       })
     });
 


### PR DESCRIPTION
*Issue:*
- Pipeline fails as it waits for a signal that is never defined
- Explicitly defining defaults for UpdatePolicy RollingUpdate does not take into account some checks performed

*Description of changes:*
- Turned off `waitOnResourceSignals` as we do not have any resource signals defined for the ASG.


*Testing done:*
- Not 100% sure how to test this change. What are others thoughts?


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
