### PR TITLE
add ECR repo for finch rootfs image

### DIFF
--- a/lib/continuous-integration-stack.ts
+++ b/lib/continuous-integration-stack.ts
@@ -1,13 +1,18 @@
 import * as cdk from 'aws-cdk-lib';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
 import { CloudfrontCdn } from './cloudfront_cdn';
 
+interface ContinuousIntegrationStackProps extends cdk.StackProps {
+  rootfsEcrRepository: ecr.Repository;
+}
+
 // ContinuousIntegrationStack - AWS stack for supporting Finch's continuous integration process
 export class ContinuousIntegrationStack extends cdk.Stack {
-  constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
+  constructor(scope: Construct, id: string, stage: string, props: ContinuousIntegrationStackProps) {
     super(scope, id, props);
 
     const githubDomain = 'token.actions.githubusercontent.com';
@@ -42,6 +47,9 @@ export class ContinuousIntegrationStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL
     });
     bucket.grantReadWrite(githubActionsRole);
+
+    const repo = props.rootfsEcrRepository;
+    repo.grantPullPush(githubActionsRole);
 
     new CloudfrontCdn(this, 'DependenciesCloudfrontCdn', {
       bucket

--- a/lib/ecr-repo-stack.ts
+++ b/lib/ecr-repo-stack.ts
@@ -1,0 +1,29 @@
+import * as cdk from 'aws-cdk-lib';
+import { CfnOutput } from 'aws-cdk-lib';
+import * as ecr from 'aws-cdk-lib/aws-ecr';
+import { Construct } from 'constructs';
+
+export class ECRRepositoryStack extends cdk.Stack {
+  public readonly repositoryOutput: CfnOutput;
+  public readonly repository: ecr.Repository;
+  constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    const repoName = `finch-rootfs-image-${stage.toLowerCase()}`;
+    const ecrRepository = new ecr.Repository(this, 'finch-rootfs', {
+        repositoryName:repoName,
+        imageTagMutability: ecr.TagMutability.IMMUTABLE,
+        // TODO: CFN does not provide APIs for enhanced image scanning. 
+        // To address, create a custom stack that uses the AWS sdk to change the account ECR 
+        // scanning settings to enhanced.
+
+        // For now, scan on image push is set to true. This means that the image will be scanned
+        // for vulnerabilites every time it is pushed up to the ECR repo. With enhanced scanning,
+        // the image would be continously scanned for vulnerabilities.
+        // See https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html
+        imageScanOnPush: true,
+    });
+
+    this.repository = ecrRepository
+    this.repositoryOutput = new CfnOutput(this, 'ECR repository', { value: ecrRepository.repositoryName });
+  }
+}

--- a/test/ecr-repo-stack.test.ts
+++ b/test/ecr-repo-stack.test.ts
@@ -1,0 +1,25 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { ECRRepositoryStack } from '../lib/ecr-repo-stack';
+
+describe('ECRRepositoryStack', () => {
+  test('synthesizes the way we expect', () => {
+    const app = new cdk.App();
+    const ecrRepo = new ECRRepositoryStack(app, 'ECRRepositoryStack', 'test');
+
+    // prepare the ECRRepositoryStack template for assertions
+    const template = Template.fromStack(ecrRepo);
+
+    // assert it creates the ecr repo with properties set.
+    template.resourceCountIs('AWS::ECR::Repository', 1);
+    template.hasResource('AWS::ECR::Repository', {
+      Properties: {
+        RepositoryName: Match.anyValue(),
+        ImageTagMutability: "IMMUTABLE",
+        ImageScanningConfiguration: {
+          ScanOnPush: true,
+        },
+      },
+    });
+  });
+})


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/runfinch/finch/issues/492

*Description of changes:*

Add an ECR repo to Finch infrastructure. this repository is where the image used as the basis for the Finch VM rootfs will live.

Context: To support Finch on Windows, we will be using WSL2. WSL2 differs from the Finch on Mac qemu/vz implementation in that WSL2 provides a kernel and requires just a root filesystem to boot a custom distribution. We will be maintaining the root filesystem as an image in this ECR repository. Subsequent PRs to finch-core will include the Dockerfile, actions for exporting the image as an archive and uploading to the Finch dependencies S3 bucket.

For now, the ECR repository is private to limit access controls to the GitHub action responsible for interacting with the image. However if in the future that proves to be cumbersome for developers, we can make the repository public for image pull and limit push permissions to the action.

*Testing done:*

`npm run test`

I also manually spun up the stack by creating mock pipeline, beta, and prod AWS accounts. Looking to add that documentation to `CONTRIBUTING.md` once I have it organized.


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
