### PR TITLE
fix: add ecr auth to GitHub Actions role

### DIFF
--- a/lib/continuous-integration-stack.ts
+++ b/lib/continuous-integration-stack.ts
@@ -50,6 +50,7 @@ export class ContinuousIntegrationStack extends cdk.Stack {
 
     const repo = props.rootfsEcrRepository;
     repo.grantPullPush(githubActionsRole);
+    ecr.AuthorizationToken.grantRead(githubActionsRole)
 
     new CloudfrontCdn(this, 'DependenciesCloudfrontCdn', {
       bucket


### PR DESCRIPTION


*Issue #, if available:*


*Description of changes:*

Need to give permissions for the GitHub Actions role to read the ECR authorization token such that it can auth to push and pull from the repo.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
