### PR TITLE
ci: add automatic GHA binary release updates

### DIFF
--- a/.github/bin/update-deps.sh
+++ b/.github/bin/update-deps.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -euxo pipefail
+
+# update-deps.sh checks for the latest versions of GitHub Actions runners using the GitHub CLI
+# and updates scripts/setup-runner.sh with this version and shas of releases.
+# GitHub CLI is preinstalled on all GitHub-hosted runners
+# https://docs.github.com/en/actions/using-workflows/using-github-cli-in-workflows
+
+latestVersion=$(gh release list --repo actions/runner --limit 10 --exclude-drafts --exclude-pre-releases | grep Latest | cut -f 1)
+
+RUNNER_VERSION_PATTERN="[0-9]+\.[0-9]+\.[0-9]+"
+X86_64_SHA_PATTERN="^.*<\!-- BEGIN SHA osx-x64 -->\([a-z0-9]\{64\}\)<\!-- END SHA osx-x64 -->"
+AARCH64_SHA_PATTERN="^.*<\!-- BEGIN SHA osx-arm64 -->\([a-z0-9]\{64\}\)<\!-- END SHA osx-arm64 -->"
+
+# find shas from release notes for the version
+X86_64_SHA=$(sed -n 's/'"${X86_64_SHA_PATTERN}"'/\1/p' <(GH_PAGER= gh release view --repo actions/runner ${latestVersion}))
+AARCH64_SHA=$(sed -n 's/'"${AARCH64_SHA_PATTERN}"'/\1/p' <(GH_PAGER= gh release view --repo actions/runner ${latestVersion}))
+
+# replace versions and shas in setup-runner.sh
+latestVersion=${latestVersion:1} # strip v from version
+sed -E  -i.bak  's/'${RUNNER_VERSION_PATTERN}'/'${latestVersion}'/g' scripts/setup-runner.sh
+sed -i.bak  's/[a-z0-9]\{64\}\(  actions-runner-osx-x64\)/'${X86_64_SHA}'\1/' scripts/setup-runner.sh
+sed -i.bak  's/[a-z0-9]\{64\}\(  actions-runner-osx-arm64\)/'${AARCH64_SHA}'\1/' scripts/setup-runner.sh

--- a/.github/workflows/update-deps.yaml
+++ b/.github/workflows/update-deps.yaml
@@ -1,0 +1,27 @@
+name: Update dependencies
+on:
+  schedule:
+    - cron: '0 11 * * 4' 
+  workflow_dispatch:
+
+jobs:
+  update-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # This step fetches the latest version of dependencies, updates that version and sha in runner setup script,
+      - name: update dependencies versions and SHAs
+        run: |
+          ./bin/update-deps.sh
+
+      - name: create PR
+        uses: peter-evans/create-pull-request@v5
+        with:
+          # A Personal Access Token instead of the default `GITHUB_TOKEN` is required
+          # to trigger the checks (e.g., e2e tests) on the created pull request.
+          # More info: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#workarounds-to-trigger-further-workflow-runs
+          token: ${{ secrets.GITHUB_TOKEN }}
+          signoff: true
+          title: 'build(deps): Bump infrastructure dependencies'

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ node_modules
 # CDK asset staging directory
 .cdk.staging
 cdk.out
+
+*.bak


### PR DESCRIPTION
*Issue #, if available:*

Closes #390 

*Description of changes:*

Adds a script that will check the releases of GitHub Actions runner binaries and updates the script this repo uses to setup the runner host with the latest version. This will run weekly and cut a PR automatically. 

*Testing done:*

Locally run `./.github/bin/update-deps.sh` and check shas with `shasum -a 256 -c`

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
