### PR TITLE
feat: add rootfs image scanning notifications

### DIFF
--- a/lib/event-bridge-scan-notifs-stack.ts
+++ b/lib/event-bridge-scan-notifs-stack.ts
@@ -1,0 +1,52 @@
+import * as cdk from 'aws-cdk-lib';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as sns from 'aws-cdk-lib/aws-sns';
+import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import { Construct } from 'constructs';
+import path from 'path';
+
+export class EventBridgeScanNotifsStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const topic = new sns.Topic(this, 'ECR Image Inspector Findings');
+
+    // Let's not expose this on GitHub, will only be visible in AWS logs Finch team owns, which is low risk.
+    // Secret has to be created only in Prod account.
+    // unsafeUnwrap is used because SNS does not have any construct that accepts a SecretValue property.
+    const securityEmail = cdk.SecretValue.secretsManager('security-notifications-email').unsafeUnwrap()
+    topic.addSubscription(new subscriptions.EmailSubscription(securityEmail.toString()));
+
+    const notificationFn = new lambda.Function(this, 'SendECRImageInspectorFindings', {
+      runtime: lambda.Runtime.PYTHON_3_11,
+      handler: 'main.lambda_handler',
+      code: lambda.Code.fromAsset(path.join(__dirname, 'image-scanning-notifications-lambda-handler')),
+      environment: {'SNS_ARN': topic.topicArn,},
+    });
+
+    const snsTopicPolicy = new iam.PolicyStatement({
+      actions: ['sns:publish'],
+      resources: ['*'],
+    });
+
+    notificationFn.addToRolePolicy(snsTopicPolicy);
+    
+    // Only publish CRITICAL and HIGH findings (more than 7.0 CVE score) that are ACTIVE
+    // https://docs.aws.amazon.com/inspector/latest/user/findings-understanding-severity.html
+    const rule = new events.Rule(this, 'rule', {
+        eventPattern: {
+          source: ['aws.inspector2'],
+          detail: {
+            severity: ['HIGH', 'CRITICAL'], 
+            status: events.Match.exactString('ACTIVE')
+          },
+          detailType: events.Match.exactString('Inspector2 Finding'),
+        },
+      });
+
+    rule.addTarget(new targets.LambdaFunction(notificationFn))
+  }
+}

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -9,6 +9,7 @@ import { ContinuousIntegrationStack } from './continuous-integration-stack';
 import { ECRRepositoryStack } from './ecr-repo-stack';
 import { PVREReportingStack } from './pvre-reporting-stack';
 import { PlatformType, RunnerProps } from '../config/runner-config';
+import { EventBridgeScanNotifsStack } from './event-bridge-scan-notifs-stack';
 
 export enum ENVIRONMENT_STAGE {
   Beta,
@@ -57,6 +58,11 @@ export class FinchPipelineAppStage extends cdk.Stage {
 
       this.ecrRepositoryOutput = ecrRepositoryStack.repositoryOutput;
       this.ecrRepository = ecrRepositoryStack.repository;
+
+      // Only report rootfs image scans in prod to avoid duplicate notifications.
+      if (props.environmentStage == ENVIRONMENT_STAGE.Prod) {
+        new EventBridgeScanNotifsStack(this, 'EventBridgeScanNotifsStack', this.stageName)
+      }
 
       new ContinuousIntegrationStack(
         this, 

--- a/lib/image-scanning-notifications-lambda-handler/main.py
+++ b/lib/image-scanning-notifications-lambda-handler/main.py
@@ -1,0 +1,64 @@
+'''
+lambda function to read ECR Image Inpsection events from Amazon EventBridge 
+and send notifications to Finch team regarding security notifications.
+'''
+import boto3
+import os
+from aws_lambda_powertools.utilities.data_classes import EventBridgeEvent
+from aws_lambda_powertools.utilities.typing import LambdaContext
+
+def build_message(event: EventBridgeEvent):
+    '''build_message reads an {event} from Inspector image scanning and builds 
+    the body of reporting email with vulnerability findings.
+
+    :param EventBridgeEvent event: The EventBridgeEvent containing an Inspector scan finding.
+
+    Schema: https://docs.aws.amazon.com/inspector/latest/user/eventbridge-integration.html#event-finding
+    '''
+    detail = event['detail']
+    title = detail['title']
+    description = detail['description']
+    severity = detail['severity']
+    source_url = detail['packageVulnerabilityDetails']['sourceUrl']
+    status = detail['status']
+    type = detail['type']
+    finding_arn = detail['findingArn']
+    first_observed_at = detail['firstObservedAt']
+
+    message = f'''{title} - Severity {severity}
+
+    Severity: {severity}
+    Type: {type}
+    Description: {description}
+    Source URL: {source_url}
+
+    Status: {status}
+    Observed: {first_observed_at}
+
+    For more info, view the finding via ARN in the AWS Console: {finding_arn}
+    '''
+
+    return message
+
+def send_sns(subject: str, message: str):
+    '''send_sns sends an email with subject and body
+    
+    :param str subject: The subject of the email
+    :param str message: The body of the email
+    '''
+    client = boto3.client("sns", region="us-west-2")
+    topic_arn = os.environ["SNS_ARN"]
+    client.publish(TopicArn=topic_arn, Message=message, Subject=subject)
+
+def lambda_handler(event: EventBridgeEvent, context: LambdaContext) -> dict:
+    detailType = event["detail-type"]
+    
+    if (detailType == "Inspector2 Finding"):
+        subject = "Rootfs Image Security Finding"
+        message = build_message(event)
+        send_sns(subject, message)
+    else:
+        print("No findings found, skipping sending email")
+
+    return {'statusCode': 200}
+    

--- a/test/event-bridge-scan-notifs-stack.test.ts
+++ b/test/event-bridge-scan-notifs-stack.test.ts
@@ -1,0 +1,49 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { EventBridgeScanNotifsStack } from '../lib/event-bridge-scan-notifs-stack';
+
+describe('EventBridgeScanNotifsStack', () => {
+  test('synthesizes the way we expect', () => {
+    const app = new cdk.App();
+    const eventBridgeStack = new EventBridgeScanNotifsStack(app, 'EventBridgeScanNotifsStack', 'test');
+
+    const template = Template.fromStack(eventBridgeStack);
+
+    template.resourceCountIs('AWS::Lambda::Function', 1);
+    template.hasResource('AWS::Lambda::Function', {
+      Properties: {
+        Environment:{
+            Variables: {
+                "SNS_ARN": Match.anyValue()
+            }
+        },
+        Runtime: "python3.11",
+      },
+    });
+
+    const lambda = template.findResources('AWS::Lambda::Function')
+    const lambdaLogicalID = Object.keys(lambda)[0]
+
+    template.resourceCountIs('AWS::SNS::Topic', 1);
+
+    template.resourceCountIs('AWS::Events::Rule', 1);
+    template.hasResource('AWS::Events::Rule', {
+        Properties: {
+            EventPattern: {
+                source: ["aws.inspector2"]
+            },
+            State: "ENABLED",
+            Targets: [
+                {
+                    "Arn":{
+                        "Fn::GetAtt": [
+                            lambdaLogicalID,
+                            "Arn"
+                        ]
+                    }
+                }
+            ],
+        }
+    });
+  });
+})


### PR DESCRIPTION
*Issue #, if available:*

Closes #357

*Description of changes:*

Amazon ECR offers Enhanced Image Scanning, which we have enabled for the rootfs image used for Finch on Windows. This change implements a stack to automatically notify Finch developers of scan results when the finding is HIGH or CRITICAL in severity (aka CVE score >= 7.0).

An SNS topic is created for the notification, and a Lambda function is wired to EventBridge to listen for events from AWS Inspector of those severities.


*Testing done:*

Manually deployment and verification of notification email. Emails received from `AWS Notifications <no-reply@sns.amazonaws.com>`. Example text below:

```text
Rootfs Image Security Finding

    Severity: HIGH
    Type: PACKAGE_VULNERABILITY
    Description: Use After Free in GitHub repository vim/vim prior to 9.0.1858.
    Source URL: https://nvd.nist.gov/vuln/detail/CVE-2023-4752

    Status: ACTIVE
    Observed: Sep 7, 2023, 11:35:24 PM

    For more info, view the finding via ARN in the AWS Console: arn:aws:inspector2:us-west-2:<redacted>:finding/<redacted>
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
