### PR TITLE
feat: add windows runner instances

### DIFF
--- a/config/runner-config.json
+++ b/config/runner-config.json
@@ -1,152 +1,223 @@
 {
     "runnerBeta": {
-        "licenseArn": "arn:aws:license-manager:us-west-2:820462304213:license-configuration:lic-7ac3e249bd13f71b44ac34963a8c3353",
+        "macLicenseArn": "arn:aws:license-manager:us-west-2:820462304213:license-configuration:lic-7ac3e249bd13f71b44ac34963a8c3353",
+        "windowsLicenseArn": "arn:aws:license-manager:us-west-2:820462304213:license-configuration:lic-56c55a611976d66a1357e58077b19e9",
         "runnerTypes": [
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "arm",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "x86",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+            },
+            {
+                "platform": "windows",
+                "version": "2022",
+                "arch": "x86",
+                "repo": "finch",
+                "desiredInstances": 1,
+                "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
+            },
+            {
+                "platform": "windows",
+                "version": "2022",
+                "arch": "x86",
+                "repo": "finch-core",
+                "desiredInstances": 1,
+                "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             }
         ]
     },
     "runnerProd": {
-        "licenseArn": "arn:aws:license-manager:us-west-2:090529234398:license-configuration:lic-c0c3e2458f6d2a45b0bcc8d66fbc072e",
+        "macLicenseArn": "arn:aws:license-manager:us-west-2:090529234398:license-configuration:lic-c0c3e2458f6d2a45b0bcc8d66fbc072e",
+        "windowsLicenseArn": "arn:aws:license-manager:us-west-2:090529234398:license-configuration:lic-62c55a61d2d9ce6ef100c6ea267216e6",
         "runnerTypes": [
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "arm",
                 "repo": "finch",
                 "desiredInstances": 2,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "x86",
                 "repo": "finch",
                 "desiredInstances": 2,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
             },
             {
-                "macOSVersion": "12.6",
+                "platform": "mac",
+                "version": "12.6",
                 "arch": "arm",
                 "repo": "finch",
                 "desiredInstances": 2,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             },
             {
-                "macOSVersion": "12.6",
+                "platform": "mac",
+                "version": "12.6",
                 "arch": "x86",
                 "repo": "finch",
                 "desiredInstances": 2,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "arm",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "x86",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
             },
             {
-                "macOSVersion": "12.6",
+                "platform": "mac",
+                "version": "12.6",
                 "arch": "arm",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             },
             {
-                "macOSVersion": "12.6",
+                "platform": "mac",
+                "version": "12.6",
                 "arch": "x86",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+            },
+            {
+                "platform": "windows",
+                "version": "2022",
+                "arch": "x86",
+                "repo": "finch",
+                "desiredInstances": 1,
+                "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
+            },
+            {
+                "platform": "windows",
+                "version": "2022",
+                "arch": "x86",
+                "repo": "finch-core",
+                "desiredInstances": 1,
+                "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             }
         ]
     },
     "runnerRelease": {
-        "licenseArn": "arn:aws:license-manager:us-east-2:019528120233:license-configuration:lic-94c3e244cb74a70c90c82f432e9e0d91",
+        "macLicenseArn": "arn:aws:license-manager:us-east-2:019528120233:license-configuration:lic-94c3e244cb74a70c90c82f432e9e0d91",
+        "windowsLicenseArn": "arn:aws:license-manager:us-east-2:019528120233:license-configuration:lic-2ec55a6280292474f1ea0d7ad6f64987",
         "runnerTypes": [
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "arm",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "x86",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "12.6",
+                "platform": "mac",
+                "version": "12.6",
                 "arch": "arm",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "12.6",
+                "platform": "mac",
+                "version": "12.6",
                 "arch": "x86",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "11.7",
+                "platform": "mac",
+                "version": "11.7",
                 "arch": "arm",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "11.7",
+                "platform": "mac",
+                "version": "11.7",
                 "arch": "x86",
                 "repo": "finch",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "arm",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "13.2",
+                "platform": "mac",
+                "version": "13.2",
                 "arch": "x86",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "11.7",
+                "platform": "mac",
+                "version": "11.7",
                 "arch": "arm",
                 "repo": "finch-core",
                 "desiredInstances": 1,
                 "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"] 
             },
             {
-                "macOSVersion": "11.7",
+                "platform": "mac",
+                "version": "11.7",
+                "arch": "x86",
+                "repo": "finch-core",
+                "desiredInstances": 1,
+                "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+            },
+            {
+                "platform": "windows",
+                "version": "2022",
+                "arch": "x86",
+                "repo": "finch",
+                "desiredInstances": 1,
+                "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+            },
+            {
+                "platform": "windows",
+                "version": "2022",
                 "arch": "x86",
                 "repo": "finch-core",
                 "desiredInstances": 1,

--- a/config/runner-config.ts
+++ b/config/runner-config.ts
@@ -1,16 +1,23 @@
 import config from './runner-config.json';
 
 export interface RunnerProps {
-  licenseArn: string;
+  macLicenseArn: string;
+  windowsLicenseArn: string;
   runnerTypes: Array<RunnerType>;
 }
 
 export interface RunnerType {
-  macOSVersion: string;
+  platform: PlatformType;
+  version: string; // e.g. 13.2 if platform == macOS, 2022 if platform == windows
   arch: string;
   repo: string;
   desiredInstances: number;
   availabilityZones: Array<string>;
+}
+
+export enum PlatformType {
+  WINDOWS = 'windows',
+  MAC = 'mac'
 }
 
 /**

--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -4,7 +4,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as resourcegroups from 'aws-cdk-lib/aws-resourcegroups';
 import { aws_autoscaling as autoscaling } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { RunnerType } from '../config/runner-config';
+import { PlatformType, RunnerType } from '../config/runner-config';
 import { readFileSync } from 'fs';
 import { ENVIRONMENT_STAGE } from './finch-pipeline-app-stage';
 import { UpdatePolicy } from 'aws-cdk-lib/aws-autoscaling';
@@ -26,8 +26,12 @@ interface ASGRunnerStackProps extends cdk.StackProps {
 export class ASGRunnerStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ASGRunnerStackProps) {
     super(scope, id, props);
-    const arch = props.type.arch === 'arm' ? 'arm64_mac' : 'x86_64_mac';
-    const instanceType = props.type.arch === 'arm' ? 'mac2.metal' : 'mac1.metal';
+
+    const platform = props.type.platform;
+    const arch = props.type.arch === 'arm' ? `arm64_${platform}` : `x86_64_${platform}`;
+    const instanceType =
+      platform === PlatformType.WINDOWS ? 'm5zn.metal' : props.type.arch === 'arm' ? 'mac2.metal' : 'mac1.metal';
+    const version = props.type.version;
 
     if (props.env == undefined) {
       throw new Error('Runner environment is undefined!');
@@ -35,17 +39,18 @@ export class ASGRunnerStack extends cdk.Stack {
 
     const vpc = cdk.aws_ec2.Vpc.fromLookup(this, 'VPC', { isDefault: true });
 
-    const securityGroup = new ec2.SecurityGroup(this, 'MacEC2SecurityGroup', {
+    const securityGroup = new ec2.SecurityGroup(this, 'EC2SecurityGroup', {
       vpc,
       description: 'Allow only outbound traffic',
       allowAllOutbound: true
     });
 
-    const role = new iam.Role(this, 'MacEC2Role', {
+    const role = new iam.Role(this, 'EC2Role', {
       assumedBy: new iam.ServicePrincipal('ec2.amazonaws.com')
     });
 
     role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
+    role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AutoScalingFullAccess'));
     role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('ResourceGroupsandTagEditorFullAccess'));
 
     // Grant EC2 instances access to secretsmanager to retrieve the GitHub api key to register runners
@@ -65,8 +70,7 @@ export class ASGRunnerStack extends cdk.Stack {
     );
 
     // Create a custom name for this as names for resource groups cannot be repeated
-    const resourceGroupName =
-      props.type.repo + '-' + 'Mac' + '-' + props.type.macOSVersion.split('.')[0] + '-' + props.type.arch + 'HostGroup';
+    const resourceGroupName = `${props.type.repo}-${platform}-${version.split('.')[0]}-${props.type.arch}HostGroup`;
 
     const resourceGroup = new resourcegroups.CfnGroup(this, resourceGroupName, {
       name: resourceGroupName,
@@ -105,30 +109,44 @@ export class ASGRunnerStack extends cdk.Stack {
       ]
     });
 
-    const macOSVersion = props.type.macOSVersion;
-    const amiSearchString = `amzn-ec2-macos-${macOSVersion}*`;
-    const macImage = new ec2.LookupMachineImage({
-      name: amiSearchString,
-      filters: {
-        'virtualization-type': ['hvm'],
-        'root-device-type': ['ebs'],
-        architecture: [arch],
-        'owner-alias': ['amazon']
-      }
-    });
+    const amiSearchString = `amzn-ec2-macos-${version}*`;
+    const machineImage =
+      platform === PlatformType.WINDOWS
+        ? ec2.MachineImage.latestWindows(ec2.WindowsVersion.WINDOWS_SERVER_2022_ENGLISH_FULL_BASE)
+        : new ec2.LookupMachineImage({
+            name: amiSearchString,
+            filters: {
+              'virtualization-type': ['hvm'],
+              'root-device-type': ['ebs'],
+              architecture: [arch],
+              'owner-alias': ['amazon']
+            }
+          });
 
-    const userData =
-      `#!/bin/bash
-    LABEL_STAGE=${props.stage === ENVIRONMENT_STAGE.Release ? 'release' : 'test'}
-    REPO=${props.type.repo}
-    REGION=${props.env?.region}
-    ` + readFileSync('./scripts/setup-runner.sh', 'utf8');
+    var userData = '';
+    if (platform === PlatformType.WINDOWS) {
+      // We need to provide user data as a yaml file to specify runAs: admin
+      // Maintain that file as yaml and source here to ensure formatting.
+      userData = readFileSync('./scripts/windows-runner-user-data.yaml', 'utf8')
+        .replace('<STAGE>', props.stage === ENVIRONMENT_STAGE.Release ? 'release' : 'test')
+        .replace('<REPO>', props.type.repo)
+        .replace('<REGION>', props.env?.region || '');
+    } else if (platform === PlatformType.MAC) {
+      userData =
+        `#!/bin/bash
+      LABEL_STAGE=${props.stage === ENVIRONMENT_STAGE.Release ? 'release' : 'test'}
+      REPO=${props.type.repo}
+      REGION=${props.env?.region}
+      ` + readFileSync('./scripts/setup-runner.sh', 'utf8');
+    }
 
-    const lt = new ec2.LaunchTemplate(this, 'MacASGLaunchTemplate', {
+    const asgName = platform === PlatformType.WINDOWS ? 'WindowsASG' : 'MacASG';
+    const ltName = `${asgName}LaunchTemplate`
+    const lt = new ec2.LaunchTemplate(this, ltName, {
       requireImdsv2: true,
       instanceType: new ec2.InstanceType(instanceType),
       keyName: 'runner-key',
-      machineImage: macImage,
+      machineImage: machineImage,
       role: role,
       securityGroup: securityGroup,
       userData: ec2.UserData.custom(userData)
@@ -161,10 +179,10 @@ export class ASGRunnerStack extends cdk.Stack {
       ]
     };
 
-    const asg = new autoscaling.AutoScalingGroup(this, 'MacASG', {
+    const asg = new autoscaling.AutoScalingGroup(this, asgName, {
       vpc,
       desiredCapacity: props.type.desiredInstances,
-      maxCapacity: props.type.desiredInstances + 2,
+      maxCapacity: props.type.desiredInstances,
       minCapacity: 0,
       healthCheck: autoscaling.HealthCheck.ec2({
         grace: cdk.Duration.seconds(3600)

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -8,7 +8,7 @@ import { ASGRunnerStack } from './asg-runner-stack';
 import { ContinuousIntegrationStack } from './continuous-integration-stack';
 import { ECRRepositoryStack } from './ecr-repo-stack';
 import { PVREReportingStack } from './pvre-reporting-stack';
-import { RunnerProps } from '../config/runner-config';
+import { PlatformType, RunnerProps } from '../config/runner-config';
 
 export enum ENVIRONMENT_STAGE {
   Beta,
@@ -30,11 +30,12 @@ export class FinchPipelineAppStage extends cdk.Stage {
   constructor(scope: Construct, id: string, props: FinchPipelineAppStageProps) {
     super(scope, id, props);
     props.runnerConfig.runnerTypes.forEach((runnerType) => {
-      const ASGStackName = 'ASG' + '-' + runnerType.repo + '-' + runnerType.macOSVersion.split('.')[0] + '-' + runnerType.arch + 'Stack'
+      const ASGStackName = `ASG-${runnerType.platform}-${runnerType.repo}-${runnerType.version.split('.')[0]}-${runnerType.arch}Stack`;
+      const licenseArn = runnerType.platform === PlatformType.WINDOWS ? props.runnerConfig.windowsLicenseArn : props.runnerConfig.macLicenseArn;
       new ASGRunnerStack(this, ASGStackName , {
         env: props.env,
         stage: props.environmentStage,
-        licenseArn: props.runnerConfig.licenseArn,
+        licenseArn: licenseArn,
         type: runnerType
       });
     });

--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -1,0 +1,139 @@
+# windows-runner-user-data.yaml
+# 
+# User Script for launching a Windows EC2 instance that:
+#  - logs to C:\UserData.log
+#  - installs winget, git, Make, AWS tools, and latest powershell
+#  - installs WSL2 and its dependencies
+#    * reboots the instance to apply the installation
+#  - periodically updates WSL2
+#  - registers as a self-hosted GitHub Actions runner on instance startup
+version: 1.0
+tasks:
+- task: executeScript
+  inputs:
+  - frequency: once
+    type: powershell
+    runAs: admin
+    content: |-
+      Start-Transcript -Path "C:\UserData.log" -Append
+      $progressPreference = 'silentlyContinue'
+      $RUNNER_DIR="C:\actions-runner"
+
+      # "<name>" values set in lib/asg-runner-stack.ts
+      $LABEL_ARCH="amd64"
+      $LABEL_STAGE="<STAGE>"
+      $REPO="<REPO>"
+      $REGION="<REGION>"
+
+      Write-Information "Installing latest powershell7 version..."
+      Invoke-Expression "& { $(Invoke-RestMethod 'https://aka.ms/install-powershell.ps1') } -useMSI -EnablePSRemoting -Quiet"
+
+      New-ItemProperty -Path "HKLM:\SOFTWARE\OpenSSH" -Name DefaultShell -Value "C:\Program Files\PowerShell\7\pwsh.exe" -PropertyType String -Force
+
+      New-Item -Path $Profile -ItemType File -Force 
+      'Set-PSReadLineOption -EditMode Emacs' | Out-File -Append $Profile
+
+      New-Item -Path $Home\setup -ItemType Directory
+      Set-Location $Home\setup
+
+      Write-Information "Installing winget and its dependencies..."
+
+      Add-AppxPackage 'https://aka.ms/Microsoft.VCLibs.x64.14.00.Desktop.appx'
+      Invoke-WebRequest -Uri https://www.nuget.org/api/v2/package/Microsoft.UI.Xaml/2.7.3 -OutFile .\microsoft.ui.xaml.2.7.3.zip
+      Expand-Archive .\microsoft.ui.xaml.2.7.3.zip
+      Add-AppxPackage .\microsoft.ui.xaml.2.7.3\tools\AppX\x64\Release\Microsoft.UI.Xaml.2.7.appx
+
+      Invoke-WebRequest -Uri https://github.com/microsoft/terminal/releases/download/v1.17.11461.0/Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle -OutFile .\Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle
+      # Install Windows Terminal
+      Add-AppxProvisionedPackage -Online -PackagePath .\Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe.msixbundle -SkipLicense
+      Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.WindowsTerminal_1.17.11461.0_8wekyb3d8bbwe
+
+      # https://github.com/microsoft/winget-cli/releases/tag/v1.6.1573-preview
+      Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.6.1573-preview/Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -OutFile  .\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle
+      Invoke-WebRequest -Uri https://github.com/microsoft/winget-cli/releases/download/v1.6.1573-preview/ba27c402ae29410eb93cfa9cb27f1376_License1.xml -OutFile .\ba27c402ae29410eb93cfa9cb27f1376_License1.xml
+
+      Add-AppxProvisionedPackage -Online -PackagePath .\Microsoft.DesktopAppInstaller_8wekyb3d8bbwe.msixbundle -LicensePath .\ba27c402ae29410eb93cfa9cb27f1376_License1.xml
+      Add-AppxPackage -RegisterByFamilyName -MainPackage Microsoft.DesktopAppInstaller_8wekyb3d8bbwe
+    
+      Write-Information "Manually update package cache and install dependencies"
+      $pws7script = @'
+      # Fix winget on Windows Server by manually updating the package cache
+      Import-Module -Name Appx -UseWindowsPowerShell  
+      Invoke-WebRequest 'https://cdn.winget.microsoft.com/cache/source.msix' -OutFile 'source.msix' -UseBasicParsing
+      Add-AppxPackage -Path source.msix
+      ECHO Y | cmd /c winget upgrade --all --silent
+      # Install dependencies via winget
+      winget install -e --id Git.Git
+      winget install -e --id GnuWin32.Make
+
+      # Install AWS tools
+      Install-Module -Name AWS.Tools.Common -Force
+      Install-Module -Name AWS.Tools.SecretsManager -Force
+      Install-Module -Name AWS.Tools.EC2 -Force
+      Install-Module -Name AWS.Tools.AutoScaling -Force
+
+      #  Install Go
+      Invoke-WebRequest -Uri 'https://go.dev/dl/go1.21.0.windows-amd64.msi' -OutFile 'go1.21.0.windows-amd64.msi'
+      Start-Process msiexec.exe -Wait -ArgumentList '/I C:\Users\Administrator\setup\go1.21.0.windows-amd64.msi /quiet'
+      # Configure path
+      $newPath = ("C:\Program Files\Git\usr\bin\;" + "$env:Path" + ";C:\Program Files\Git\bin\;" + "C:\Program Files (x86)\GnuWin32\bin\;" + "C:\Program Files\Go\bin\;") 
+      $env:Path = $newPath
+      # Persist the path to the registry for new shells
+      Set-ItemProperty -Path 'Registry::HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment' -Name PATH -Value $newPath
+      '@
+    
+      # Write PowerShell 7 script to file
+      $pws7script | Out-File $Home\setup\setup7.ps1
+    
+      # Execute script with PowerShell 7
+      $ConsoleCommand = "$Home\setup\setup7.ps1"
+      Start-Process "C:\Program Files\PowerShell\7\pwsh" -Wait -NoNewWindow -PassThru -ArgumentList "-Command  &{ $ConsoleCommand }"
+
+      Write-Information "Downloading and configuring GitHub Actions Runner..."
+      mkdir $RUNNER_DIR; cd $RUNNER_DIR
+      Invoke-WebRequest -Uri https://github.com/actions/runner/releases/download/v2.309.0/actions-runner-win-x64-2.309.0.zip -OutFile actions-runner-win-x64-2.309.0.zip
+      if((Get-FileHash -Path actions-runner-win-x64-2.309.0.zip -Algorithm SHA256).Hash.ToUpper() -ne 'cd1920154e365689130aa1f90258e0da47faecce547d0374475cdd2554dbf09a'.ToUpper()){ throw 'Computed checksum did not match' }
+      Add-Type -AssemblyName System.IO.Compression.FileSystem ;  [System.IO.Compression.ZipFile]::ExtractToDirectory("$PWD/actions-runner-win-x64-2.309.0.zip", "$PWD")
+
+      $GH_KEY=(Get-SECSecretValue -SecretId $REPO-runner-reg-key -Region $REGION).SecretString
+      $LABEL_OS_VER=$([System.Environment]::OSVersion.Version.Major)
+      $LABEL_BUILD_VER=$([System.Environment]::OSVersion.Version.Build)
+
+      $RUNNER_REG_TOKEN=((Invoke-WebRequest -UseBasicParsing -Method POST -Headers @{"Accept" = "application/vnd.github+json"; "Authorization" =  "Bearer $GH_KEY";  "X-GitHub-Api-Version" = "2022-11-28"} -Uri https://api.github.com/repos/runfinch/$REPO/actions/runners/registration-token).Content | ConvertFrom-Json).token
+
+      Write-Information "Starting GitHub Actions Runner..."
+      cd $RUNNER_DIR; ./config.cmd --url https://github.com/runfinch/$REPO --unattended --runasservice --token  $RUNNER_REG_TOKEN --work _work --labels $LABEL_ARCH,$LABEL_OS_VER,$LABEL_BUILD_VER,$LABEL_STAGE
+
+      # To install WSL2, the instance must be rebooted: https://learn.microsoft.com/en-us/windows/wsl/install
+      # To accomplish this while not replacing the instance in the autoscaling group,
+      #
+      # 1. Put the instance in "StandBy" mode
+      # 2. Register a powershell script to be run at instance reboot on login
+      # 3. Install WSL2 and restart the instance
+
+      $InstanceId=(Get-EC2InstanceMetadata -Category InstanceId)
+      $ASGName=(Get-ASAutoScalingInstance -InstanceId $InstanceId).AutoScalingGroupName
+      Enter-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId -ShouldDecrementDesiredCapacity $true
+
+      # Script runs on login after reboot;
+      $startupscript = @'
+      Start-Service "actions.runner.*"
+      Exit-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId
+      '@
+
+      # Write startup powershell script to file. 
+      # $ExecutionContext.InvokeCommand.ExpandString will evaluate variables first, so the ASG and instance ID are specified
+      Set-Content 'C:\startup.ps1' ($ExecutionContext.InvokeCommand.ExpandString($startupscript))
+
+      # Register a scheduled job to run the script to regist the instance as a runner on boot.
+      $trigger = New-JobTrigger -AtStartup -RandomDelay 00:00:30
+      Register-ScheduledJob -Trigger $trigger -FilePath C:\startup.ps1 -Name startup-job-inservice
+
+      # Register a scheduled job to attempt a WSL update every day between 10:00am and 10:20am.
+      $trigger = New-JobTrigger -Daily -At 10:00 -RandomDelay 00:20:00
+      Register-ScheduledJob -Trigger $trigger -Name auto-update-wsl2 -ScriptBlock {
+        wsl --update
+      }
+
+      wsl --install
+      Restart-Computer


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
* change RunnerType to include platform
* refactor asg-runner-stack to build for both platform types macOS and
  windows
* add windows-runner-user-data.yaml with PowerShell script to set up
    runner
* update runner-config.json to include Windows runners for beta, prod, and release
* add licenses for Windows
* refactor to define 'windows' and 'mac' as a `PlatformType` `enum`


`windows-runner-user-data.yaml` is a User Script for launching a Windows EC2 instance that:

- logs to C:\UserData.log
- installs winget, git, Make, AWS tools, and latest powershell
- installs WSL2 and its dependencies
  * reboots the instance to apply the installation
- periodically updates WSL2
- registers as a self-hosted GitHub Actions runner on instance startup

*Testing done:*

`npm run test`

`npm run cdk test`

Local stack setup. Confirmation of instance InService in ASG with WSL installed and registered as a runner:
```
PS C:\Windows\system32> wsl -l -v
Windows Subsystem for Linux has no installed distributions.
Distributions can be installed by visiting the Microsoft Store:
https://aka.ms/wslstore

PS C:\Windows\system32> Get-Service "actions.runner.*"

Status   Name               DisplayName
------   ----               -----------
Running  actions.runner.... GitHub Actions Runner (ginglis13-fi...
```

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
