### PR TITLE
fix: give the actions runner service system privileges

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -116,7 +116,9 @@ tasks:
       Enter-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId -ShouldDecrementDesiredCapacity $true
 
       # Script runs on login after reboot;
+      $ServiceName=(Get-Service actions.runner.*).name
       $startupscript = @'
+      Invoke-Expression "cmd.exe /c sc config $ServiceName obj= 'NT AUTHORITY\SYSTEM' type= own"
       Start-Service "actions.runner.*"
       Exit-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId
       '@


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

By default, the GitHub actions runner will run as the NetworkService account.
The GitHub Actions runner user is the [NetworkService Account](https://learn.microsoft.com/en-us/windows/win32/services/networkservice-account?redirectedfrom=MSDN). This account does not have administrator privileges: https://github.com/ginglis13/finch/actions/runs/6303042315/job/17111485195?pr=1
```
Run whoami
  whoami
  $currentPrincipal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
  $currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
  shell: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.EXE -command ". '{0}'"
NETWORK SERVICE
False
```

https://github.com/actions/runner/issues/408 describes a workaround to provide privileges to the runner service, which this commit implements

*Testing done:*

Run instance in dev account with updated launch template, verify privileges in GHA 👍 
https://github.com/ginglis13/finch/actions/runs/6303042315/job/17115973658?pr=1

- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
