### PR TITLE
fix: runs GHA service on Windows as Administrator

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -120,7 +120,7 @@ tasks:
       $ServiceName=(Get-Service actions.runner.*).name
       $startupscript = @'
       Start-Transcript -Path "C:\StartupScript.log" -Append
-      Invoke-Expression "cmd.exe /c sc config $ServiceName obj= 'NT AUTHORITY\SYSTEM' type= own"
+      Invoke-Expression "cmd.exe /c sc config $ServiceName obj= '$(hostname)\Administrator' type= own"
       Invoke-WebRequest -Uri 'https://github.com/microsoft/WSL/releases/download/2.0.2/wsl.2.0.2.0.x64.msi' -OutFile 'C:\Users\Administrator\setup\wsl.2.0.2.0.x64.msi'
       Start-Process msiexec.exe -Wait -ArgumentList '/i C:\Users\Administrator\setup\wsl.2.0.2.0.x64.msi /L*V C:\WSLInstallation.log /quiet'
       Start-Service "actions.runner.*"


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

Previously, the GitHub Actions runner service was running under a local system account that did that have full permissions to run wsl. Change ownership of the service to the local Administrator account so all wsl commands will work as expected.

*Testing done:*



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
