### PR TITLE
fix: increase size of root volume for runners

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -140,6 +140,12 @@ export class ASGRunnerStack extends cdk.Stack {
       ` + readFileSync('./scripts/setup-runner.sh', 'utf8');
     }
 
+    // Create a 100GiB volume to be used as instance root volume
+    const rootVolume: ec2.BlockDevice = {
+      deviceName: '/dev/sda1',
+      volume: ec2.BlockDeviceVolume.ebs(100),
+    };
+
     const asgName = platform === PlatformType.WINDOWS ? 'WindowsASG' : 'MacASG';
     const ltName = `${asgName}LaunchTemplate`
     const lt = new ec2.LaunchTemplate(this, ltName, {
@@ -149,7 +155,8 @@ export class ASGRunnerStack extends cdk.Stack {
       machineImage: machineImage,
       role: role,
       securityGroup: securityGroup,
-      userData: ec2.UserData.custom(userData)
+      userData: ec2.UserData.custom(userData),
+      blockDevices: [rootVolume]
     });
 
     // Escape hatch to cfnLaunchTemplate as the L2 construct lacked some required


### PR DESCRIPTION


*Issue #, if available:*


*Description of changes:*

While {mac1,mac2}.metal instances default to a size of 100GiB for their respective root volumes on EC2, m5zn.metal instances default to a size of 30GiB for the root volume. Specify explicit size to keep consistency between the two platforms and to avoid potential issues with storage limits hit.

See https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.LaunchTemplate.html#construct-props and https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2.BlockDevice.html

`/dev/sda1` is a placeholder name for the root volume on both macOS and Windows EC2 instances

*Testing done:*

`npm run cdk synth`

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
