### PR TITLE
fix: install Ubuntu WSL distro in startup script

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -123,6 +123,8 @@ tasks:
       Invoke-WebRequest -Uri 'https://github.com/microsoft/WSL/releases/download/2.0.2/wsl.2.0.2.0.x64.msi' -OutFile 'C:\Users\Administrator\setup\wsl.2.0.2.0.x64.msi'
       Start-Process msiexec.exe -Wait -ArgumentList '/i C:\Users\Administrator\setup\wsl.2.0.2.0.x64.msi /L*V C:\WSLInstallation.log /quiet'
       Exit-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId
+      Start-Process -NoNewWindow -FilePath wsl -ArgumentList '--install Ubuntu'
+      sleep 30 # sleep to allow Ubuntu VM to start
       New-NetFirewallRule -DisplayName "WSL" -Direction Inbound -InterfaceAlias "vEthernet (WSL)" -Action Allow
       '@
 


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

PR #441 added a firewall rule to allow inbound traffic to the WSL VM. However, no WSL VM is started in this startup script, so no interfaces were available to provide to the rule. CI changes in the main Finch repo were taking care of launching a Ubuntu distro. Better practice would be to install that distro in the init script of the runner itself.


*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
