### PR TITLE
ci: Add one more windows CI runner

### DIFF
--- a/config/runner-config.json
+++ b/config/runner-config.json
@@ -110,7 +110,7 @@
                 "version": "2022",
                 "arch": "x86",
                 "repo": "finch",
-                "desiredInstances": 1,
+                "desiredInstances": 2,
                 "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"] 
             },
             {


### PR DESCRIPTION
*Issue #, if available:*
Currently only have one windows CI runner in finch repo, which stack a lot PRs.
For macOS, we have 2 instances per os & arch for CI purpose, add one more windows to keep them consistent and efficient.

*Description of changes:*
Change the instance count to 2



- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
