### PR TITLE
fix: use default boto3 client region

### DIFF
--- a/lib/image-scanning-notifications-lambda-handler/main.py
+++ b/lib/image-scanning-notifications-lambda-handler/main.py
@@ -44,7 +44,7 @@ def send_sns(subject: str, message: str):
     :param str subject: The subject of the email
     :param str message: The body of the email
     '''
-    client = boto3.client("sns", region="us-west-2")
+    client = boto3.client("sns")
     topic_arn = os.environ["SNS_ARN"]
     client.publish(TopicArn=topic_arn, Message=message, Subject=subject)
 


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

`region` is not a valid keyword arg to the boto3.client API. fix to remove named parameter in order to default to the region the function is deployed in.


*Testing done:*

test invokes on lambda func

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
