### PR TITLE
fix: add NuGet back (Carbon dependency)

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -36,7 +36,11 @@ tasks:
       New-Item -Path $Home\setup -ItemType Directory
       Set-Location $Home\setup
     
-      Write-Information "Install dependencies git, make, go, AWS tools, and update path..."
+      Write-Information "Install dependencies git, make, go, AWS tools, NuGet and update path..."
+
+      # Install latest NuGet so that Carbon installation works later
+      Install-PackageProvider -Name NuGet -Force
+
       $pws7script = @'
       Start-Transcript -Path "$Home\setup\setup7.log" -Append
       Import-Module -Name Appx -UseWindowsPowerShell  


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
NuGet is a Carbon dependency and we use Carbon to manipulate the GitHub Runner service. In the last PR, I removed it because it wasn't obvious why we needed it

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
