### PR TITLE
revert: wsl update scheduled job

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -133,12 +133,6 @@ tasks:
           $trigger = New-JobTrigger -AtStartup -RandomDelay 00:00:30
           Register-ScheduledJob -Trigger $trigger -FilePath C:\startup.ps1 -Name startup-job-inservice
 
-          # Register a scheduled job to attempt a WSL update every day between 10:00am and 10:20am.
-          $trigger = New-JobTrigger -Daily -At 10:00 -RandomDelay 00:20:00
-          Register-ScheduledJob -Trigger $trigger -Name auto-update-wsl2 -ScriptBlock {
-            wsl --update --pre-release
-          }
-
           Write-Information "Changing GHA service ownership to Administrator..."
           [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
           Install-Module -Name 'Carbon' -AllowClobber -Force


### PR DESCRIPTION
*Issue #, if available:*
All Windows tests seems to be failing with similar errors:
- https://github.com/runfinch/finch/actions/runs/8976482356/job/24653433668?pr=928


*Description of changes:*
- Remove the scheduled job that tries to update WSL as it may cause instability. WSL versions can be updated manually if needed, or by changing the user data script and refreshing the hosts.
- Not sure if this is the culprit but it will at least make the testing environments saner by not changing dependency versions automatically

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
