### PR TITLE
feat: enable termination protection on CloudFormation stacks

### DIFF
--- a/lib/artifact-bucket-cloudfront.ts
+++ b/lib/artifact-bucket-cloudfront.ts
@@ -5,12 +5,15 @@ import { Construct } from 'constructs';
 
 import { CloudfrontCdn } from './cloudfront_cdn';
 import * as s3Deployment from 'aws-cdk-lib/aws-s3-deployment';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 export class ArtifactBucketCloudfrontStack extends cdk.Stack {
   public readonly urlOutput: CfnOutput;
   public readonly bucket: s3.Bucket;
   constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
+
     const bucketName = `finch-artifact-bucket-${stage.toLowerCase()}-${cdk.Stack.of(this)?.account}`;
     const artifactBucket = new s3.Bucket(this, 'ArtifactBucket', {
       bucketName,

--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -8,6 +8,7 @@ import { PlatformType, RunnerType } from '../config/runner-config';
 import { readFileSync } from 'fs';
 import { ENVIRONMENT_STAGE } from './finch-pipeline-app-stage';
 import { UpdatePolicy } from 'aws-cdk-lib/aws-autoscaling';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 interface ASGRunnerStackProps extends cdk.StackProps {
   env: cdk.Environment | undefined;
@@ -26,6 +27,7 @@ interface ASGRunnerStackProps extends cdk.StackProps {
 export class ASGRunnerStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: ASGRunnerStackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
 
     const platform = props.type.platform;
     const arch = props.type.arch === 'arm' ? `arm64_${platform}` : `x86_64_${platform}`;

--- a/lib/aspects/stack-termination-protection.ts
+++ b/lib/aspects/stack-termination-protection.ts
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+// Finch Infrastructure
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import { Aspects, IAspect, Stack } from "aws-cdk-lib";
+import { IConstruct } from "constructs";
+
+/**
+ * Enable termination protection in all stacks.
+ */
+export class EnableTerminationProtectionOnStacks implements IAspect {
+    visit(construct: IConstruct): void {
+        if (Stack.isStack(construct)) {
+            (<any>construct).terminationProtection = true;
+        }
+    }
+}
+
+export function applyTerminationProtectionOnStacks(constructs: IConstruct[]) {
+    constructs.forEach((construct) => {
+        Aspects.of(construct).add(new EnableTerminationProtectionOnStacks());
+    })
+}

--- a/lib/continuous-integration-stack.ts
+++ b/lib/continuous-integration-stack.ts
@@ -5,6 +5,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 
 import { CloudfrontCdn } from './cloudfront_cdn';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 interface ContinuousIntegrationStackProps extends cdk.StackProps {
   rootfsEcrRepository: ecr.Repository;
@@ -14,6 +15,7 @@ interface ContinuousIntegrationStackProps extends cdk.StackProps {
 export class ContinuousIntegrationStack extends cdk.Stack {
   constructor(scope: Construct, id: string, stage: string, props: ContinuousIntegrationStackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
 
     const githubDomain = 'token.actions.githubusercontent.com';
 

--- a/lib/ecr-repo-stack.ts
+++ b/lib/ecr-repo-stack.ts
@@ -2,12 +2,15 @@ import * as cdk from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import { Construct } from 'constructs';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 export class ECRRepositoryStack extends cdk.Stack {
   public readonly repositoryOutput: CfnOutput;
   public readonly repository: ecr.Repository;
   constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
+
     const repoName = `finch-rootfs-image-${stage.toLowerCase()}`;
     const ecrRepository = new ecr.Repository(this, 'finch-rootfs', {
         repositoryName:repoName,

--- a/lib/event-bridge-scan-notifs-stack.ts
+++ b/lib/event-bridge-scan-notifs-stack.ts
@@ -7,10 +7,12 @@ import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
 import * as targets from 'aws-cdk-lib/aws-events-targets';
 import { Construct } from 'constructs';
 import path from 'path';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 export class EventBridgeScanNotifsStack extends cdk.Stack {
   constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
 
     const topic = new sns.Topic(this, 'ECR Image Inspector Findings');
 

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -68,10 +68,10 @@ export class FinchPipelineAppStage extends cdk.Stage {
         this, 
         'FinchContinuousIntegrationStack', 
         this.stageName, 
-        {rootfsEcrRepository: this.ecrRepository}
+        { rootfsEcrRepository: this.ecrRepository }
       );
     }
 
-    new PVREReportingStack(this, 'PVREReportingStack');
+    new PVREReportingStack(this, 'PVREReportingStack', { terminationProtection:true });
   }
 }

--- a/lib/finch-pipeline-stack.ts
+++ b/lib/finch-pipeline-stack.ts
@@ -5,10 +5,12 @@ import { Construct } from 'constructs';
 import { EnvConfig } from '../config/env-config';
 import { RunnerConfig } from '../config/runner-config';
 import { ENVIRONMENT_STAGE, FinchPipelineAppStage } from './finch-pipeline-app-stage';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 export class FinchPipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
 
     const source = CodePipelineSource.gitHub('runfinch/infrastructure', 'main', {
       authentication: cdk.SecretValue.secretsManager('pipeline-github-access-token')

--- a/lib/pvre-reporting-stack.ts
+++ b/lib/pvre-reporting-stack.ts
@@ -1,10 +1,12 @@
 import * as cdk from 'aws-cdk-lib';
 import * as cfninc from 'aws-cdk-lib/cloudformation-include';
 import { Construct } from 'constructs';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
 
 export class PVREReportingStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {
     super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
 
     new cfninc.CfnInclude(this, 'PVREReportingTemplate', {
       templateFile: 'lib/pvre-reporting-template.yml'

--- a/test/artifact-bucket-cloudfront.test.ts
+++ b/test/artifact-bucket-cloudfront.test.ts
@@ -28,5 +28,7 @@ describe('ArtifactBucketCloudfrontStack', () => {
 
     // assert it creates the cloudfront distribution
     template.resourceCountIs('AWS::CloudFront::Distribution', 1);
+
+    expect(cloudfront.terminationProtection).toBeTruthy();
   });
 });

--- a/test/asg-runner-stack.test.ts
+++ b/test/asg-runner-stack.test.ts
@@ -54,4 +54,10 @@ describe('ASGRunnerStack test', () => {
       });
     });
   });
+
+  it('must have termination protection enabled', () => {
+    stacks.forEach((stack) => {
+      expect(stack.terminationProtection).toBeTruthy();
+    })
+  });
 });

--- a/test/aspects/stack-termination-protection.test.ts
+++ b/test/aspects/stack-termination-protection.test.ts
@@ -1,0 +1,20 @@
+// Finch Infrastructure
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+import { App, Stack } from "aws-cdk-lib";
+import { Bucket } from "aws-cdk-lib/aws-s3";
+import { applyTerminationProtectionOnStacks } from "../../lib/aspects/stack-termination-protection";
+
+describe('Stack termination protection aspect', () => {
+    it('must enable termination protection when applied to a stack and synthesized', () => {
+        const app = new App();
+        const stack = new Stack(app, 'FooStack');
+        // stack needs one resource
+        new Bucket(stack, 'BarBucket');
+
+        applyTerminationProtectionOnStacks([stack]);
+        app.synth();
+
+        expect(stack.terminationProtection).toBeTruthy();
+    });
+});

--- a/test/ecr-repo-stack.test.ts
+++ b/test/ecr-repo-stack.test.ts
@@ -21,5 +21,7 @@ describe('ECRRepositoryStack', () => {
         },
       },
     });
+
+    expect(ecrRepo.terminationProtection).toBeTruthy();
   });
 })

--- a/test/event-bridge-scan-notifs-stack.test.ts
+++ b/test/event-bridge-scan-notifs-stack.test.ts
@@ -45,5 +45,7 @@ describe('EventBridgeScanNotifsStack', () => {
             ],
         }
     });
+
+    expect(eventBridgeStack.terminationProtection).toBeTruthy();
   });
 })

--- a/test/finch-pipeline-stack.test.ts
+++ b/test/finch-pipeline-stack.test.ts
@@ -57,5 +57,7 @@ describe('FinchPipelineStack', () => {
         'Fn::GetAtt': ['FinchPipelineRole198D7E07', 'Arn']
       }
     });
+
+    expect(stack.terminationProtection).toBeTruthy();
   });
 });


### PR DESCRIPTION
*Issue #, if available:*
It is recommended to enable termination protection for CloudFormation stacks. Finch infrastructure currently does this for FinchPipelineStack but not for all stacks.

*Description of changes:*
This change enables termination protection on all CloudFormation stacks.

*Testing done:*
```
npm run test
```


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Austin Vazquez <macedonv@amazon.com>