### PR TITLE
refactor: resolve cdk warnings for ec2 key pair

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -145,11 +145,11 @@ export class ASGRunnerStack extends cdk.Stack {
     // Create a 100GiB volume to be used as instance root volume
     const rootVolume: ec2.BlockDevice = {
       deviceName: '/dev/sda1',
-      volume: ec2.BlockDeviceVolume.ebs(100),
+      volume: ec2.BlockDeviceVolume.ebs(100)
     };
 
     const asgName = platform === PlatformType.WINDOWS ? 'WindowsASG' : 'MacASG';
-    const ltName = `${asgName}LaunchTemplate`
+    const ltName = `${asgName}LaunchTemplate`;
     const lt = new ec2.LaunchTemplate(this, ltName, {
       requireImdsv2: true,
       instanceType: new ec2.InstanceType(instanceType),
@@ -207,9 +207,9 @@ export class ASGRunnerStack extends cdk.Stack {
           autoscaling.ScalingProcess.REPLACE_UNHEALTHY,
           autoscaling.ScalingProcess.AZ_REBALANCE,
           autoscaling.ScalingProcess.ALARM_NOTIFICATION,
-          autoscaling.ScalingProcess.SCHEDULED_ACTIONS,
+          autoscaling.ScalingProcess.SCHEDULED_ACTIONS
         ],
-        waitOnResourceSignals: false,
+        waitOnResourceSignals: false
       })
     });
 

--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -153,7 +153,7 @@ export class ASGRunnerStack extends cdk.Stack {
     const lt = new ec2.LaunchTemplate(this, ltName, {
       requireImdsv2: true,
       instanceType: new ec2.InstanceType(instanceType),
-      keyName: 'runner-key',
+      keyPair: ec2.KeyPair.fromKeyPairName(this, 'KeyPair', 'runner-key'),
       machineImage: machineImage,
       role: role,
       securityGroup: securityGroup,

--- a/lib/continuous-integration-stack.ts
+++ b/lib/continuous-integration-stack.ts
@@ -52,7 +52,7 @@ export class ContinuousIntegrationStack extends cdk.Stack {
 
     const repo = props.rootfsEcrRepository;
     repo.grantPullPush(githubActionsRole);
-    ecr.AuthorizationToken.grantRead(githubActionsRole)
+    ecr.AuthorizationToken.grantRead(githubActionsRole);
 
     new CloudfrontCdn(this, 'DependenciesCloudfrontCdn', {
       bucket

--- a/lib/ecr-repo-stack.ts
+++ b/lib/ecr-repo-stack.ts
@@ -13,20 +13,20 @@ export class ECRRepositoryStack extends cdk.Stack {
 
     const repoName = `finch-rootfs-image-${stage.toLowerCase()}`;
     const ecrRepository = new ecr.Repository(this, 'finch-rootfs', {
-        repositoryName:repoName,
-        imageTagMutability: ecr.TagMutability.IMMUTABLE,
-        // TODO: CFN does not provide APIs for enhanced image scanning. 
-        // To address, create a custom stack that uses the AWS sdk to change the account ECR 
-        // scanning settings to enhanced.
+      repositoryName: repoName,
+      imageTagMutability: ecr.TagMutability.IMMUTABLE,
+      // TODO: CFN does not provide APIs for enhanced image scanning.
+      // To address, create a custom stack that uses the AWS sdk to change the account ECR
+      // scanning settings to enhanced.
 
-        // For now, scan on image push is set to true. This means that the image will be scanned
-        // for vulnerabilites every time it is pushed up to the ECR repo. With enhanced scanning,
-        // the image would be continously scanned for vulnerabilities.
-        // See https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html
-        imageScanOnPush: true,
+      // For now, scan on image push is set to true. This means that the image will be scanned
+      // for vulnerabilites every time it is pushed up to the ECR repo. With enhanced scanning,
+      // the image would be continously scanned for vulnerabilities.
+      // See https://docs.aws.amazon.com/AmazonECR/latest/userguide/image-scanning-enhanced.html
+      imageScanOnPush: true
     });
 
-    this.repository = ecrRepository
+    this.repository = ecrRepository;
     this.repositoryOutput = new CfnOutput(this, 'ECR repository', { value: ecrRepository.repositoryName });
   }
 }

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -32,8 +32,11 @@ export class FinchPipelineAppStage extends cdk.Stage {
     super(scope, id, props);
     props.runnerConfig.runnerTypes.forEach((runnerType) => {
       const ASGStackName = `ASG-${runnerType.platform}-${runnerType.repo}-${runnerType.version.split('.')[0]}-${runnerType.arch}Stack`;
-      const licenseArn = runnerType.platform === PlatformType.WINDOWS ? props.runnerConfig.windowsLicenseArn : props.runnerConfig.macLicenseArn;
-      new ASGRunnerStack(this, ASGStackName , {
+      const licenseArn =
+        runnerType.platform === PlatformType.WINDOWS
+          ? props.runnerConfig.windowsLicenseArn
+          : props.runnerConfig.macLicenseArn;
+      new ASGRunnerStack(this, ASGStackName, {
         env: props.env,
         stage: props.environmentStage,
         licenseArn: licenseArn,
@@ -50,28 +53,21 @@ export class FinchPipelineAppStage extends cdk.Stage {
       this.artifactBucketCloudfrontUrlOutput = artifactBucketCloudfrontStack.urlOutput;
       this.cloudfrontBucket = artifactBucketCloudfrontStack.bucket;
 
-      const ecrRepositoryStack = new ECRRepositoryStack(
-        this,
-        'ECRRepositoryStack',
-        this.stageName
-      );
+      const ecrRepositoryStack = new ECRRepositoryStack(this, 'ECRRepositoryStack', this.stageName);
 
       this.ecrRepositoryOutput = ecrRepositoryStack.repositoryOutput;
       this.ecrRepository = ecrRepositoryStack.repository;
 
       // Only report rootfs image scans in prod to avoid duplicate notifications.
       if (props.environmentStage == ENVIRONMENT_STAGE.Prod) {
-        new EventBridgeScanNotifsStack(this, 'EventBridgeScanNotifsStack', this.stageName)
+        new EventBridgeScanNotifsStack(this, 'EventBridgeScanNotifsStack', this.stageName);
       }
 
-      new ContinuousIntegrationStack(
-        this, 
-        'FinchContinuousIntegrationStack', 
-        this.stageName, 
-        { rootfsEcrRepository: this.ecrRepository }
-      );
+      new ContinuousIntegrationStack(this, 'FinchContinuousIntegrationStack', this.stageName, {
+        rootfsEcrRepository: this.ecrRepository
+      });
     }
 
-    new PVREReportingStack(this, 'PVREReportingStack', { terminationProtection:true });
+    new PVREReportingStack(this, 'PVREReportingStack', { terminationProtection: true });
   }
 }

--- a/test/asg-runner-stack.test.ts
+++ b/test/asg-runner-stack.test.ts
@@ -58,6 +58,6 @@ describe('ASGRunnerStack test', () => {
   it('must have termination protection enabled', () => {
     stacks.forEach((stack) => {
       expect(stack.terminationProtection).toBeTruthy();
-    })
+    });
   });
 });

--- a/test/ecr-repo-stack.test.ts
+++ b/test/ecr-repo-stack.test.ts
@@ -15,13 +15,13 @@ describe('ECRRepositoryStack', () => {
     template.hasResource('AWS::ECR::Repository', {
       Properties: {
         RepositoryName: Match.anyValue(),
-        ImageTagMutability: "IMMUTABLE",
+        ImageTagMutability: 'IMMUTABLE',
         ImageScanningConfiguration: {
-          ScanOnPush: true,
-        },
-      },
+          ScanOnPush: true
+        }
+      }
     });
 
     expect(ecrRepo.terminationProtection).toBeTruthy();
   });
-})
+});

--- a/test/event-bridge-scan-notifs-stack.test.ts
+++ b/test/event-bridge-scan-notifs-stack.test.ts
@@ -12,40 +12,37 @@ describe('EventBridgeScanNotifsStack', () => {
     template.resourceCountIs('AWS::Lambda::Function', 1);
     template.hasResource('AWS::Lambda::Function', {
       Properties: {
-        Environment:{
-            Variables: {
-                "SNS_ARN": Match.anyValue()
-            }
+        Environment: {
+          Variables: {
+            SNS_ARN: Match.anyValue()
+          }
         },
-        Runtime: "python3.11",
-      },
+        Runtime: 'python3.11'
+      }
     });
 
-    const lambda = template.findResources('AWS::Lambda::Function')
-    const lambdaLogicalID = Object.keys(lambda)[0]
+    const lambda = template.findResources('AWS::Lambda::Function');
+    const lambdaLogicalID = Object.keys(lambda)[0];
 
     template.resourceCountIs('AWS::SNS::Topic', 1);
 
     template.resourceCountIs('AWS::Events::Rule', 1);
     template.hasResource('AWS::Events::Rule', {
-        Properties: {
-            EventPattern: {
-                source: ["aws.inspector2"]
-            },
-            State: "ENABLED",
-            Targets: [
-                {
-                    "Arn":{
-                        "Fn::GetAtt": [
-                            lambdaLogicalID,
-                            "Arn"
-                        ]
-                    }
-                }
-            ],
-        }
+      Properties: {
+        EventPattern: {
+          source: ['aws.inspector2']
+        },
+        State: 'ENABLED',
+        Targets: [
+          {
+            Arn: {
+              'Fn::GetAtt': [lambdaLogicalID, 'Arn']
+            }
+          }
+        ]
+      }
     });
 
     expect(eventBridgeStack.terminationProtection).toBeTruthy();
   });
-})
+});


### PR DESCRIPTION
*Issue #, if available:*

CDK is showing warnings for usage of deprecated attribute in EC2 launch template.

```
[WARNING] aws-cdk-lib.aws_ec2.LaunchTemplateProps#keyName is deprecated.
  - Use `keyPair` instead - https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.aws_ec2-readme.html#using-an-existing-ec2-key-pair
  This API will be removed in the next major release.
```

*Description of changes:*
This change refactors key pair specification in the EC2 launch template to use recommended field `keyPair` and applies the formatter.

*Testing done:*
Unit tests are successful

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
