### PR TITLE
feat: add linux runners

### DIFF
--- a/config/env-config.ts
+++ b/config/env-config.ts
@@ -1,5 +1,5 @@
-import config from './env-config.json';
 import * as cdk from 'aws-cdk-lib';
+import config from './env-config.json';
 
 /**
  * Class for environment configurations. Outlines the account and region.

--- a/config/runner-config.json
+++ b/config/runner-config.json
@@ -9,7 +9,12 @@
         "arch": "arm",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -17,7 +22,12 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "windows",
@@ -25,7 +35,12 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "windows",
@@ -33,7 +48,64 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2023",
+        "arch": "x86",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2",
+        "arch": "x86",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2023",
+        "arch": "arm",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2",
+        "arch": "arm",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       }
     ]
   },
@@ -47,7 +119,12 @@
         "arch": "arm",
         "repo": "finch",
         "desiredInstances": 2,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -55,7 +132,12 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 2,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -63,7 +145,12 @@
         "arch": "arm",
         "repo": "finch",
         "desiredInstances": 2,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -71,7 +158,12 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 2,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -79,7 +171,12 @@
         "arch": "arm",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -87,7 +184,12 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -95,7 +197,12 @@
         "arch": "arm",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "mac",
@@ -103,7 +210,12 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "windows",
@@ -111,7 +223,12 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 2,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       },
       {
         "platform": "windows",
@@ -119,7 +236,64 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-west-2a", "us-west-2b", "us-west-2c", "us-west-2d"]
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2023",
+        "arch": "x86",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2",
+        "arch": "x86",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2023",
+        "arch": "arm",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
+      },
+      {
+        "platform": "amazonlinux",
+        "version": "2",
+        "arch": "arm",
+        "repo": "finch",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-west-2a",
+          "us-west-2b",
+          "us-west-2c",
+          "us-west-2d"
+        ]
       }
     ]
   },
@@ -133,7 +307,11 @@
         "arch": "arm",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "mac",
@@ -141,7 +319,11 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "mac",
@@ -149,7 +331,11 @@
         "arch": "arm",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "mac",
@@ -157,7 +343,11 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "mac",
@@ -165,7 +355,11 @@
         "arch": "arm",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "mac",
@@ -173,7 +367,11 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "windows",
@@ -181,7 +379,11 @@
         "arch": "x86",
         "repo": "finch",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       },
       {
         "platform": "windows",
@@ -189,7 +391,11 @@
         "arch": "x86",
         "repo": "finch-core",
         "desiredInstances": 1,
-        "availabilityZones": ["us-east-2a", "us-east-2b", "us-east-2c"]
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
       }
     ]
   }

--- a/config/runner-config.ts
+++ b/config/runner-config.ts
@@ -3,12 +3,18 @@ import config from './runner-config.json';
 export interface RunnerProps {
   macLicenseArn: string;
   windowsLicenseArn: string;
+  linuxLicenseArn: string;
   runnerTypes: Array<RunnerType>;
 }
 
 export interface RunnerType {
   platform: PlatformType;
-  version: string; // e.g. 13.2 if platform == macOS, 2022 if platform == windows
+  /** Different values for different platforms.
+   * For mac, a version like 13.2
+   * For windows, a server version like 2022
+   * For amazonlinux, either 2, 2023, etc.
+   * For fedora, a version like 40, 41, etc. */
+  version: string;
   arch: string;
   repo: string;
   desiredInstances: number;
@@ -17,7 +23,8 @@ export interface RunnerType {
 
 export enum PlatformType {
   WINDOWS = 'windows',
-  MAC = 'mac'
+  MAC = 'mac',
+  AMAZONLINUX = 'amazonlinux',
 }
 
 /**

--- a/lib/finch-pipeline-stack.ts
+++ b/lib/finch-pipeline-stack.ts
@@ -4,8 +4,8 @@ import { CodePipeline, CodePipelineSource, ShellStep } from 'aws-cdk-lib/pipelin
 import { Construct } from 'constructs';
 import { EnvConfig } from '../config/env-config';
 import { RunnerConfig } from '../config/runner-config';
-import { ENVIRONMENT_STAGE, FinchPipelineAppStage } from './finch-pipeline-app-stage';
 import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
+import { ENVIRONMENT_STAGE, FinchPipelineAppStage } from './finch-pipeline-app-stage';
 
 export class FinchPipelineStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props?: cdk.StackProps) {

--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -17,9 +17,10 @@ eval "OS_VERSION=\"\${${OS_RELEASE_PREFIX}_VERSION_ID}\""
 if [ "${OS_NAME}" = "Amazon Linux" ]; then
     USERNAME="ec2-user"
     DISTRO="amazonlinux"
+    BASE_PACKAGES="golang zlib-static containerd nerdctl cni-plugins iptables"
     if [ "${OS_VERSION}" = "2" ]; then
         GH_RUNNER_DEPENDENCIES="openssl krb5-libs zlib jq"
-        ADDITIONAL_PACKAGES="policycoreutils-python ${GH_RUNNER_DEPENDENCIES}"
+        ADDITIONAL_PACKAGES="policycoreutils-python systemd-rpm-macros ${GH_RUNNER_DEPENDENCIES}"
     elif [ "${OS_VERSION}" = "2023" ]; then
         GH_RUNNER_DEPENDENCIES="lttng-ust openssl-libs krb5-libs zlib libicu"
         ADDITIONAL_PACKAGES="policycoreutils-python-utils ${GH_RUNNER_DEPENDENCIES}"
@@ -33,35 +34,27 @@ mkdir -p "${RUNNER_DIR}" && cd "${HOMEDIR}"
 # TODO: add check for non-Fedora based systems if needed
 yum upgrade
 yum group install -y "Development Tools"
-if [ ! -z "${ADDITIONAL_PACKAGES}" ]; then
-    yum install -y ${ADDITIONAL_PACKAGES}
-fi
+# build dependencies for packages
+# this sometimes fails on Amazon Linux 2023, so retry if necessary
+for i in {1..2}; do
+    yum install -y ${BASE_PACKAGES} ${ADDITIONAL_PACKAGES} && break || sleep 5
+done
+
+# start containerd
+systemctl enable --now containerd
 
 # configure download parameters based on architecture
 UNAME_MACHINE="$(/usr/bin/uname -m)"
 if [ "${UNAME_MACHINE}" = "aarch64" ]; then
-    GO_ARCH="arm64"
-    GO_DOWNLOAD_HASH="c15fa895341b8eaf7f219fada25c36a610eb042985dc1a912410c1c90098eaf2"
     GH_RUNNER_ARCH="arm64"
     GH_RUNNER_DOWNLOAD_HASH="524e75dc384ba8289fcea4914eb210f10c8c4e143213cef7d28f0c84dd2d017c"
 else
-    GO_ARCH="amd64"
-    GO_DOWNLOAD_HASH="999805bed7d9039ec3da1a53bfbcafc13e367da52aa823cb60b68ba22d44c616"
     GH_RUNNER_ARCH="x64"
     GH_RUNNER_DOWNLOAD_HASH="52b8f9c5abb1a47cc506185a1a20ecea19daf0d94bbf4ddde7e617e7be109b14"
 fi
 
-GO_FILENAME="go1.22.6.linux-${GO_ARCH}.tar.gz"
-GO_DOWNLOAD_URL="https://go.dev/dl/${GO_FILENAME}"
-
 GH_RUNNER_FILENAME="actions-runner-linux-${GH_RUNNER_ARCH}-2.319.0.tar.gz"
 GH_RUNNER_DOWNLOAD_URL="https://github.com/actions/runner/releases/download/v2.319.0/${GH_RUNNER_FILENAME}"
-
-curl -OL "${GO_DOWNLOAD_URL}"
-echo "${GO_DOWNLOAD_HASH}  ${GO_FILENAME}" | sha256sum -c
-rm -rf /usr/local/go && tar -C /usr/local -xzf "./${GO_FILENAME}"
-echo "export PATH=$PATH:/usr/local/go/bin" > /etc/profile.d/go.sh
-rm "${GO_FILENAME}"
 
 curl -OL "${GH_RUNNER_DOWNLOAD_URL}"
 echo "${GH_RUNNER_DOWNLOAD_HASH}  ${GH_RUNNER_FILENAME}" | sha256sum -c
@@ -80,7 +73,6 @@ RUNNER_REG_TOKEN=$(curl -L -s \
     -H "X-GitHub-Api-Version: 2022-11-28" \
     "https://api.github.com/repos/runfinch/${REPO}/actions/runners/registration-token" | jq -r '.token')
 
-
 if [ -z ${GH_RUNNER_DEPENDENCIES+x} ]; then
     echo "Executing installdependencies.sh because GH_RUNNER_DEPENDENCIES is not defined."
     "${RUNNER_DIR}/bin/installdependencies.sh"
@@ -88,7 +80,7 @@ fi
 
 # Configure the runner with the registration token, launch the service
 # these commands must NOT be run as root
-sudo -i -u "${USERNAME}" bash << EOF
+sudo -i -u "${USERNAME}" bash <<EOF
 "${RUNNER_DIR}/config.sh" --url "https://github.com/runfinch/${REPO}" --unattended --token "${RUNNER_REG_TOKEN}" --work _work --labels "${LABEL_ARCH},${DISTRO},${OS_VERSION},${LABEL_STAGE}"
 EOF
 

--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/bash
+
+# The user data script is run as root so do not use sudo command
+
+# Log output
+exec &>/var/log/setup-runner.log
+echo $0
+
+# load all variables from /etc/os-release prefixed with OS_RELEASE as to not clobber
+OS_RELEASE_PREFIX="OS_RELEASE"
+source <(sed -Ee "s/^([^#])/${OS_RELEASE_PREFIX}_\1/" "/etc/os-release")
+
+# set variables to make accessing values in /etc/os-release easier
+eval "OS_NAME=\"\${${OS_RELEASE_PREFIX}_NAME}\""
+eval "OS_VERSION=\"\${${OS_RELEASE_PREFIX}_VERSION_ID}\""
+
+if [ "${OS_NAME}" = "Amazon Linux" ]; then
+    USERNAME="ec2-user"
+    DISTRO="amazonlinux"
+    if [ "${OS_VERSION}" = "2" ]; then
+        GH_RUNNER_DEPENDENCIES="openssl krb5-libs zlib jq"
+        ADDITIONAL_PACKAGES="policycoreutils-python ${GH_RUNNER_DEPENDENCIES}"
+    elif [ "${OS_VERSION}" = "2023" ]; then
+        GH_RUNNER_DEPENDENCIES="lttng-ust openssl-libs krb5-libs zlib libicu"
+        ADDITIONAL_PACKAGES="policycoreutils-python-utils ${GH_RUNNER_DEPENDENCIES}"
+    fi
+fi
+
+HOMEDIR="/home/${USERNAME}"
+RUNNER_DIR="${HOMEDIR}/ar"
+mkdir -p "${RUNNER_DIR}" && cd "${HOMEDIR}"
+
+# TODO: add check for non-Fedora based systems if needed
+yum upgrade
+yum group install -y "Development Tools"
+if [ ! -z "${ADDITIONAL_PACKAGES}" ]; then
+    yum install -y ${ADDITIONAL_PACKAGES}
+fi
+
+# configure download parameters based on architecture
+UNAME_MACHINE="$(/usr/bin/uname -m)"
+if [ "${UNAME_MACHINE}" = "aarch64" ]; then
+    GO_ARCH="arm64"
+    GO_DOWNLOAD_HASH="c15fa895341b8eaf7f219fada25c36a610eb042985dc1a912410c1c90098eaf2"
+    GH_RUNNER_ARCH="arm64"
+    GH_RUNNER_DOWNLOAD_HASH="524e75dc384ba8289fcea4914eb210f10c8c4e143213cef7d28f0c84dd2d017c"
+else
+    GO_ARCH="amd64"
+    GO_DOWNLOAD_HASH="999805bed7d9039ec3da1a53bfbcafc13e367da52aa823cb60b68ba22d44c616"
+    GH_RUNNER_ARCH="x64"
+    GH_RUNNER_DOWNLOAD_HASH="52b8f9c5abb1a47cc506185a1a20ecea19daf0d94bbf4ddde7e617e7be109b14"
+fi
+
+GO_FILENAME="go1.22.6.linux-${GO_ARCH}.tar.gz"
+GO_DOWNLOAD_URL="https://go.dev/dl/${GO_FILENAME}"
+
+GH_RUNNER_FILENAME="actions-runner-linux-${GH_RUNNER_ARCH}-2.319.0.tar.gz"
+GH_RUNNER_DOWNLOAD_URL="https://github.com/actions/runner/releases/download/v2.319.0/${GH_RUNNER_FILENAME}"
+
+curl -OL "${GO_DOWNLOAD_URL}"
+echo "${GO_DOWNLOAD_HASH}  ${GO_FILENAME}" | sha256sum -c
+rm -rf /usr/local/go && tar -C /usr/local -xzf "./${GO_FILENAME}"
+echo "export PATH=$PATH:/usr/local/go/bin" > /etc/profile.d/go.sh
+rm "${GO_FILENAME}"
+
+curl -OL "${GH_RUNNER_DOWNLOAD_URL}"
+echo "${GH_RUNNER_DOWNLOAD_HASH}  ${GH_RUNNER_FILENAME}" | sha256sum -c
+tar -C "${RUNNER_DIR}" -xzf "./${GH_RUNNER_FILENAME}"
+chown -R "${USERNAME}:${USERNAME}" "${RUNNER_DIR}"
+rm "${GH_RUNNER_FILENAME}"
+
+# TODO: install SSM agent on non-AL hosts if needed
+
+# Get GH API key and fetch a runner registration token
+GH_KEY=$(aws secretsmanager get-secret-value --secret-id $REPO-runner-reg-key --region $REGION | jq '.SecretString' -r)
+RUNNER_REG_TOKEN=$(curl -L -s \
+    -X POST \
+    -H "Accept: application/vnd.github+json" \
+    -H "Authorization: Bearer $GH_KEY" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    "https://api.github.com/repos/runfinch/${REPO}/actions/runners/registration-token" | jq -r '.token')
+
+
+if [ -z ${GH_RUNNER_DEPENDENCIES+x} ]; then
+    echo "Executing installdependencies.sh because GH_RUNNER_DEPENDENCIES is not defined."
+    "${RUNNER_DIR}/bin/installdependencies.sh"
+fi
+
+# Configure the runner with the registration token, launch the service
+# these commands must NOT be run as root
+sudo -i -u "${USERNAME}" bash << EOF
+"${RUNNER_DIR}/config.sh" --url "https://github.com/runfinch/${REPO}" --unattended --token "${RUNNER_REG_TOKEN}" --work _work --labels "${LABEL_ARCH},${DISTRO},${OS_VERSION},${LABEL_STAGE}"
+EOF
+
+# these commands need to be run from "runner root" as the root user
+cd "${RUNNER_DIR}"
+# fix SELinux perms so systemctl can execute
+semanage fcontext -d "${RUNNER_DIR}/runsvc.sh"
+semanage fcontext -a -t "bin_t" "${RUNNER_DIR}/runsvc.sh"
+./svc.sh install "${USERNAME}"
+restorecon -Fv "${RUNNER_DIR}/runsvc.sh"
+./svc.sh start


### PR DESCRIPTION
*Issue #, if available:*
Adding Linux e2e test runners In support of https://github.com/runfinch/finch/pull/1023

*Description of changes:*
- Adds Amazon Linux 2 and 2023 runners
  - Only added for finch repo for now, because there's no value in testing finch-core changes on Linux as they do not impact finch on linux functionality
- User data setup script configured in a way that makes it easy to extend support to other Linux varieties

*Testing done:*
- Unit tests
- Tested in my own stack


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
