### PR TITLE
fix: switch/case statement fallthrough

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -85,6 +85,7 @@ export class ASGRunnerStack extends cdk.Stack implements IASGRunnerStack {
         });
         asgName = 'MacASG';
         userDataString = this.userData(props, 'setup-runner.sh');
+        break;
       }
       case PlatformType.WINDOWS: {
         instanceType = ec2.InstanceType.of(ec2.InstanceClass.M5ZN, ec2.InstanceSize.METAL);
@@ -96,6 +97,7 @@ export class ASGRunnerStack extends cdk.Stack implements IASGRunnerStack {
           .replace('<STAGE>', props.stage === ENVIRONMENT_STAGE.Release ? 'release' : 'test')
           .replace('<REPO>', props.type.repo)
           .replace('<REGION>', props.env?.region || '');
+          break;
       }
       case PlatformType.AMAZONLINUX: {
         // Linux instances do not have to be metal, since the only mode of operation
@@ -120,6 +122,7 @@ export class ASGRunnerStack extends cdk.Stack implements IASGRunnerStack {
             cpuType
           });
         }
+        break;
       }
     }
 

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -36,9 +36,11 @@ export class FinchPipelineAppStage extends cdk.Stage {
       switch (runnerType.platform) {
         case PlatformType.MAC: {
           licenseArn = props.runnerConfig.macLicenseArn;
+          break;
         }
         case PlatformType.WINDOWS: {
           licenseArn = props.runnerConfig.windowsLicenseArn;
+          break;
         }
       }
       new ASGRunnerStack(this, ASGStackName, {

--- a/test/asg-runner-stack.test.ts
+++ b/test/asg-runner-stack.test.ts
@@ -50,6 +50,7 @@ describe('ASGRunnerStack test', () => {
       switch (type.platform) {
         case PlatformType.WINDOWS: {
           instanceType = 'm5zn.metal';
+          break;
         }
         case PlatformType.MAC: {
           if (type.arch === 'arm') {
@@ -57,6 +58,7 @@ describe('ASGRunnerStack test', () => {
           } else {
             instanceType = 'mac1.metal';
           }
+          break;
         }
         case PlatformType.AMAZONLINUX: {
           if (type.arch === 'arm') {
@@ -64,6 +66,7 @@ describe('ASGRunnerStack test', () => {
           } else {
             instanceType = 'c7a.large';
           }
+          break;
         }
       }
       template.hasResourceProperties('AWS::EC2::LaunchTemplate', {


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Been writing too much go and forgot that typescript switch/case statements fallthrough by default. We should consider changing our tscofing's `noFallthroughCasesInSwitch` setting separately

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
