### PR TITLE
ci: add macOS 12 hosts for building finch-core lima archive

### DIFF
--- a/config/runner-config.json
+++ b/config/runner-config.json
@@ -374,6 +374,30 @@
         ]
       },
       {
+        "platform": "mac",
+        "version": "12.7",
+        "arch": "arm",
+        "repo": "finch-core",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
+      },
+      {
+        "platform": "mac",
+        "version": "12.7",
+        "arch": "x86",
+        "repo": "finch-core",
+        "desiredInstances": 1,
+        "availabilityZones": [
+          "us-east-2a",
+          "us-east-2b",
+          "us-east-2c"
+        ]
+      },
+      {
         "platform": "windows",
         "version": "2022",
         "arch": "x86",


### PR DESCRIPTION
*Issue #, if available:*
Currently, we are using macOS 11 runners to build this archive. macOS 11 is deprecated, and we are no longer able to install our dependencies, which is causing runs to fail. 


<details>

<summary>Error excerpt for https://github.com/runfinch/finch-core/actions/runs/11342859343/job/31544196556#step:5:174
</summary>

```
==> Installing qemu dependency: python-packaging
==> Downloading https://ghcr.io/v2/homebrew/core/python-packaging/manifests/24.1_1
Already downloaded: /Users/ec2-user/Library/Caches/Homebrew/downloads/0a8b3181cb4fa8bee143a75cd85f08eb834903bde31ef0a291f3fe9f82bdbe41--python-packaging-24.1_1.bottle_manifest.json
==> Pouring python-packaging--24.1_1.all.bottle.tar.gz
🍺  /opt/homebrew/Cellar/python-packaging/24.1_1: 74 files, 545.5KB
==> Installing qemu
==> ./configure --cc=clang --host-cc=clang --disable-bsd-user --disable-guest-ag
==> make V=1 install
Last 15 lines from /Users/ec2-user/Library/Logs/Homebrew/qemu/02.make:
        kAudioObjectPropertyElementName
/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/System/Library/Frameworks/CoreAudio.framework/Headers/AudioHardwareBase.h:331:5: note: 'kAudioObjectPropertyElementName' declared here
    kAudioObjectPropertyElementName         = 'lchn',
    ^
6 errors generated.
[1900/6485] clang -Ilibcommon.a.p -I/opt/homebrew/Cellar/capstone/5.0.3/include/capstone -I/opt/homebrew/Cellar/libidn2/2.3.7/include -I/opt/homebrew/Cellar/libtasn1/4.19.0/include -I/opt/homebrew/Cellar/nettle/3.10/include -I/opt/homebrew/Cellar/p11-kit/0.25.5/include/p11-kit-1 -I/opt/homebrew/Cellar/gnutls/3.8.4/include -I/opt/homebrew/Cellar/pixman/0.42.2/include/pixman-1 -I/opt/homebrew/opt/libpng/include/libpng16 -I/opt/homebrew/Cellar/spice-protocol/0.14.4/include/spice-1 -I/opt/homebrew/Cellar/jpeg-turbo/3.0.4/include -I/opt/homebrew/Cellar/libusb/1.0.27/include/libusb-1.0 -I/opt/homebrew/Cellar/pcre2/10.44/include -I/opt/homebrew/Cellar/glib/2.82.1/include -I/opt/homebrew/Cellar/glib/2.82.1/include/glib-2.0 -I/opt/homebrew/Cellar/glib/2.82.1/lib/glib-2.0/include -I/opt/homebrew/opt/gettext/include -I/Library/Developer/CommandLineTools/SDKs/MacOSX11.sdk/usr/include/ffi -I/opt/homebrew/Cellar/glib/2.82.1/include/gio-unix-2.0 -I/opt/homebrew/opt/zstd/include -I/opt/homebrew/Cellar/libslirp/4.8.0/include/slirp -I/opt/homebrew/Cellar/ncurses/6.5/include/ncursesw -I/opt/homebrew/Cellar/ncurses/6.5/include -I/opt/homebrew/Cellar/libssh/0.11.1/include -fdiagnostics-color=auto -Wall -Winvalid-pch -std=gnu11 -O2 -g -fstack-protector-strong -Wempty-body -Wendif-labels -Wexpansion-to-defined -Wformat-security -Wformat-y2k -Wignored-qualifiers -Winit-self -Wmissing-format-attribute -Wmissing-prototypes -Wnested-externs -Wold-style-definition -Wredundant-decls -Wstrict-prototypes -Wtype-limits -Wundef -Wvla -Wwrite-strings -Wno-gnu-variable-sized-type-not-at-end -Wno-initializer-overrides -Wno-missing-include-dirs -Wno-psabi -Wno-shift-negative-value -Wno-string-plus-int -Wno-tautological-type-limit-compare -Wno-typedef-redefinition -iquote . -iquote /private/tmp/qemu-20241015-49204-gqnm39/qemu-9.1.0 -iquote /private/tmp/qemu-20241015-49204-gqnm39/qemu-9.1.0/include -iquote /private/tmp/qemu-20241015-49204-gqnm39/qemu-9.1.0/host/include/aarch64 -iquote /private/tmp/qemu-20241015-49204-gqnm39/qemu-9.1.0/host/include/generic -iquote /private/tmp/qemu-20241015-49204-gqnm39/qemu-9.1.0/tcg/aarch64 -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -fno-strict-aliasing -fno-common -fwrapv -fno-pie -D_DARWIN_C_SOURCE -DNCURSES_WIDECHAR -DNCURSES_WIDECHAR=1 -DSTRUCT_IOVEC_DEFINED -MD -MQ libcommon.a.p/fsdev_qemu-fsdev-dummy.c.o -MF libcommon.a.p/fsdev_qemu-fsdev-dummy.c.o.d -o libcommon.a.p/fsdev_qemu-fsdev-dummy.c.o -c ../fsdev/qemu-fsdev-dummy.c
```
</details>


*Description of changes:*
This change adds macOS 12 runners for with the finch-core "release" tag, which will allow us fix our builds.


*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
