### PR TITLE
ci: remove erroneous restorecon

### DIFF
--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -126,8 +126,6 @@ EOF
 # these commands need to be run from "runner root" as the root user
 cd "${RUNNER_DIR}"
 # fix SELinux perms so systemctl can execute
-semanage fcontext -d "${RUNNER_DIR}/runsvc.sh"
 semanage fcontext -a -t "bin_t" "${RUNNER_DIR}/runsvc.sh"
 ./svc.sh install "${USERNAME}"
-restorecon -Fv "${RUNNER_DIR}/runsvc.sh"
 ./svc.sh start


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- Remove erroneous `restorecon`
  - restorecon was erroring out and is unnecessary for things in the `${RUNNERDIR}` since we already set context with `semanage` in the preceding lines:
```
ValueError: File context for /home/ec2-user/ar/runsvc.sh is not defined
```
  - This was never realized before because we were not using `set -e` for this script
  - This was causing the ec2 user data script to exit before running the GH runner `./svc.sh install` and `./svc.sh start` scripts
  - The failure of the user-data script does not cause the instances to go into a failure state. We should add that as a followup (not sure how straightforward that is)

*Testing done:*
- Executed on runners


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
