### PR TITLE
ci(fix): escape nested variable

### DIFF
--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -107,9 +107,10 @@ fi
 
 # replace any bundled node binary with a symlink to system node
 find "${RUNNER_DIR}" -wholename "${RUNNER_DIR}/externals/node*/bin/node" | while read line; do
-    rm -rf $line
-    ln -s ${SYSTEM_NODE_PATH} $line
+    rm -rf \$line
+    ln -s ${SYSTEM_NODE_PATH} \$line
 done
+
 EOF
 
     chmod +x ${RUNNER_PATCH_SCRIPT}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fix for #870
- Previously tested that the find/remove/symlink logic worked, but didn't test that writing the script to the file worked. It did not, because the $ for $line needs to be escaped.

*Testing done:*
- Tested the cating to file logic, to make sure the full $line makes it to the end script


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
