### PR TITLE
ci: add defender exception

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -125,7 +125,8 @@ tasks:
           Invoke-WebRequest -Uri 'https://wslstorestorage.blob.core.windows.net/wslblob/wsl_update_x64.msi' -OutFile 'C:\Users\Administrator\setup\wsl_update_x64.msi'
           Start-Process msiexec.exe -Wait -ArgumentList '/i C:\Users\Administrator\setup\wsl_update_x64.msi /L*V C:\WSLInstallation.log /quiet'
           Exit-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId
-          Start-Process -NoNewWindow -FilePath wsl -ArgumentList '--install Ubuntu'
+          Add-MpPreference -ExclusionPath "C:\Users\ADMINI~1\AppData\Local\Temp\go-build*" -Force
+          Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath wsl -ArgumentList '--install Ubuntu' }
           sleep 30 # sleep to allow Ubuntu VM to start
           New-NetFirewallRule -DisplayName "WSL" -Direction Inbound -InterfaceAlias "vEthernet (WSL)" -Action Allow
           '@


### PR DESCRIPTION
*Issue #, if available:* https://github.com/runfinch/finch/actions/runs/13950287431/job/39048083043#step:14:45
> [github.com/runfinch/finch/e2e/vm.test](http://github.com/runfinch/finch/e2e/vm.test): open C:\Users\ADMINI~1\AppData\Local\Temp\go-build3463726325\b001\vm.test.exe: Operation did not complete successfully because the file contains a virus or potentially unwanted software.

*Description of changes:*
- Adds a Windows Defender exception for the temporary go test generated executables

*Testing done:*
- Manually ran command on host


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
