### PR TITLE
ci: fix externals find

### DIFF
--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -106,7 +106,7 @@ if grep -q "${ORIGINAL_NODE_PATH}" "${RUNSVC_PATH}"; then
 fi
 
 # replace any bundled node binary with a symlink to system node
-find "${RUNNER_DIR}" -wholename "${RUNNER_DIR}/externals/node*/bin/node" | while read line; do
+find "${RUNNER_DIR}" -wholename "${RUNNER_DIR}/externals*/node*/bin/node" | while read line; do
     rm -rf \$line
     ln -s ${SYSTEM_NODE_PATH} \$line
 done


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Recently, the Amazon Linux 2 CI/CD runner's GitHub action agent was updated in place. This caused a replacement of the externals directory. The actions runner does not simply delete/re-create or in-place replace the externals directory. It uses a symlink to point `externals` to the new suffixed `externals.version-number` directory. This causes `externals` to not show up in the results of the existing `find` command.

The new find command will pick up all of these suffixed `externals` directories, and properly replace the pre-packaged node binary with the system binary that we installed previously.

*Testing done:*
- Ran script on hosts manually


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
