### PR TITLE
ci: make yum upgrade not require user interaction

### DIFF
--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -49,7 +49,7 @@ RUNNER_DIR="${HOMEDIR}/ar"
 mkdir -p "${RUNNER_DIR}" && cd "${HOMEDIR}"
 
 # TODO: add check for non-Fedora based systems if needed
-yum upgrade
+yum upgrade -y
 yum group install -y "Development Tools"
 # build dependencies for packages
 # this sometimes fails on Amazon Linux 2023, so retry if necessary


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Make yum upgrade non-interactive. Somehow, we have never hit this case before, but if there are any packages that need to be upgraded, the command will just fail because its not attached to any input

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
