### PR TITLE
feat: codebuild stack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 !jest.config.unit.js
 *.d.ts
 node_modules
+dist
 
 # CDK asset staging directory
 .cdk.staging

--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -1,0 +1,119 @@
+import * as cdk from 'aws-cdk-lib';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import * as ec2 from 'aws-cdk-lib/aws-ec2';
+import { Construct } from 'constructs';
+import { Key } from 'aws-cdk-lib/aws-kms';
+import { toStackName, GITHUB_ALLOWLISTED_ACCOUNT_IDS, BuildImageOS, LinuxAMIBuildImage, WindowsAMIBuildImage, MacAMIBuildImage } from './utils';
+
+const webhookFiltersArr: codebuild.FilterGroup[] = [];
+
+for (const userId of GITHUB_ALLOWLISTED_ACCOUNT_IDS) {
+    console.log('creating filter group for userid: ', userId);
+    webhookFiltersArr.push(codebuild.FilterGroup.inEventOf(codebuild.EventAction.WORKFLOW_JOB_QUEUED).andActorAccountIs(userId));
+}
+
+const githHubSource = codebuild.Source.gitHub({
+    owner: 'runfinch',
+    repo: 'finch',
+    webhook: true,
+    webhookFilters: webhookFiltersArr,
+});
+
+/**
+ * Default properties for CodeBuildStack configuration.
+ * Contains static readonly properties that define default values for image filters,
+ * fleet configuration, and project environment settings.
+ */
+class CodeBuildStackDefaultProps {
+    static readonly imageFilterProps = {
+      virtualizationType: ['hvm'],
+      rootDeviceType: ['ebs'],
+      ownerAlias: ['amazon'],
+    };
+    static readonly fleetProps = {
+        computeType: codebuild.FleetComputeType.MEDIUM,
+        baseCapacity: 1,
+    };
+    static readonly projectEnvironmentProps = {
+        computeType: codebuild.ComputeType.MEDIUM,
+        privileged: true,
+    };
+}
+
+class CodeBuildStackProps {
+    env: cdk.Environment | undefined;
+    projectName: string;
+    region: string;
+    arch: string;
+    amiSearchString: string;
+    environmentType: codebuild.EnvironmentType;
+    buildImageOS: BuildImageOS;
+    imageFilterProps?: {
+        virtualizationType: string[],
+        rootDeviceType: string[],
+        ownerAlias: string[],
+    };
+    fleetProps?: {
+        computeType: codebuild.FleetComputeType,
+        baseCapacity: number,
+    };
+    projectEnvironmentProps?: {
+        computeType: codebuild.ComputeType,
+        privileged: boolean,
+    };
+}
+
+export class CodeBuildStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props: CodeBuildStackProps) {
+        super(scope, id, props);
+        this.createBuildProject(props, id);
+    }
+
+    private createBuildProject(props: CodeBuildStackProps, id: string): codebuild.Project {
+        const machineImage = new ec2.LookupMachineImage({
+            name: props.amiSearchString,
+            filters: {
+                ...(props.imageFilterProps || CodeBuildStackDefaultProps.imageFilterProps),
+                'architecture': [props.arch],
+            }
+        });
+
+        const fleet = new codebuild.Fleet(this, `Fleet-${toStackName(props.arch)}`, {
+            ...(props.fleetProps || CodeBuildStackDefaultProps.fleetProps),
+            environmentType: props.environmentType,
+        });
+
+        const imageId: string = machineImage.getImage(this).imageId;
+        
+        const cfnFleet = fleet.node.defaultChild as cdk.CfnResource;
+        cfnFleet.addPropertyOverride('ImageId', imageId);
+    
+        return new codebuild.Project(this, id, {
+            projectName: props.projectName,
+            source: githHubSource,
+            environment: {
+                ...(props.projectEnvironmentProps || CodeBuildStackDefaultProps.projectEnvironmentProps),
+                fleet: fleet,
+                buildImage: this.getBuildImageByOS(props.buildImageOS, imageId),
+            },
+            encryptionKey: new Key(this, `codebuild-${toStackName(props.arch)}-key-${props.region}`, {
+                description: 'Kms Key to encrypt data-at-rest',
+                alias: `finch-${props.arch}-kms-${props.region}`,
+                enabled: true,
+            })
+        });
+    }
+
+    private getBuildImageByOS(os: BuildImageOS, imageId: string): cdk.aws_codebuild.IBuildImage {
+        switch(os) {
+            case BuildImageOS.LINUX:
+                return new LinuxAMIBuildImage(imageId);
+            case BuildImageOS.MAC:
+                return new MacAMIBuildImage(imageId);
+            case BuildImageOS.WINDOWS:
+                return new WindowsAMIBuildImage(imageId);
+            default:
+                throw new Error(`Unsupported Build Image OS: ${os}`);
+        }
+    }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,0 +1,70 @@
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+
+
+export const CODEBUILD_ARCHS: string[] = ['x86_64_ubuntu', 'arm64_ubuntu'];
+
+// members of the runfinch org (+dependabot)
+// curl -s https://api.github.com/users/<username> | jq '.id'
+// TODO: automate fetching account ID's
+export const GITHUB_ALLOWLISTED_ACCOUNT_IDS = [
+    '47769978',     // coderbirju
+    '424987',       // pendo324
+    '55906459',     // austinvazquez
+    '2304727',      // Kern--
+    '2967759',      // henry118
+    '47723536',     // Shubhranshu153
+    '55555210',     // sondavidb
+    '5525370',      // swagatbora90
+    '59450965',     // cezar-r
+    '49699333',     // dependabot[bot] github app
+];
+
+/**
+ * Replaces all underscores with hyphens in a string.
+ * Used for making strings compatible with stack names, which don't allow "_" in the name.
+ * 
+ * @param name The string to process
+ * @returns A new string with all underscores replaced by hyphens
+ */
+export const toStackName = (name: string) => {
+  return name.replace(/_/g, '-');
+}
+
+export enum BuildImageOS {
+  LINUX = "linux",
+  WINDOWS = "windows",
+  MAC = "mac",
+}
+
+// @ts-expect-error Extending private class
+export class LinuxAMIBuildImage extends codebuild.LinuxBuildImage implements codebuild.IBuildImage {
+    declare type: codebuild.EnvironmentType;
+    
+    constructor(imageId: string) {
+        // @ts-expect-error Extending private class
+        super({ imageId });
+        this.type = codebuild.EnvironmentType.LINUX_EC2;
+    }
+}
+
+// @ts-expect-error Extending private class
+export class WindowsAMIBuildImage extends codebuild.WindowsBuildImage implements codebuild.IBuildImage {
+    declare type: codebuild.EnvironmentType;
+
+    constructor(imageId: string) {
+        // @ts-expect-error Extending private class
+        super({ imageId });
+        this.type = codebuild.EnvironmentType.WINDOWS_EC2;
+    }
+}
+
+// @ts-expect-error Extending private class
+export class MacAMIBuildImage extends codebuild.LinuxBuildImage implements codebuild.IBuildImage {
+    declare type: codebuild.EnvironmentType;
+
+    constructor(imageId: string) {
+        // @ts-expect-error Extending private class
+        super({ imageId });
+        this.type = codebuild.EnvironmentType.MAC_ARM;
+    }
+}

--- a/test/codebuild-stack.test.ts
+++ b/test/codebuild-stack.test.ts
@@ -1,0 +1,63 @@
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { CodeBuildStack } from '../lib/codebuild-stack';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import { BuildImageOS } from '../lib/utils';
+
+describe('CodeBuildStack', () => {
+  test('synthesizes the way we expect', () => {
+    const app = new cdk.App();
+    const stack = new CodeBuildStack(app, 'TestStack', {
+        env: {
+            account: '123456789012',
+            region: 'us-east-1'
+        },
+        projectName: 'test-project',
+        region: 'us-west-2',
+        arch: 'x86_64_ubuntu',
+        amiSearchString: 'ubuntu*22.04*',
+        environmentType: codebuild.EnvironmentType.LINUX_EC2,
+        buildImageOS: BuildImageOS.LINUX,
+    });
+    const template = Template.fromStack(stack);
+
+    // Assert that the stack creates a CodeBuild project
+    template.hasResourceProperties('AWS::CodeBuild::Project', {
+      Name: 'test-project',
+      Environment: {
+        Type: 'LINUX_EC2',
+        ComputeType: 'BUILD_GENERAL1_MEDIUM',
+        Image: Match.stringLikeRegexp('ami-1234'),
+        PrivilegedMode: true
+      },
+      Source: {
+        Type: 'GITHUB',
+        Location: 'https://github.com/runfinch/finch.git',
+        ReportBuildStatus: true
+      }
+    });
+
+    // Assert that the stack creates a Fleet
+    template.hasResourceProperties('AWS::CodeBuild::Fleet', {
+      BaseCapacity: 1,
+      ComputeType: 'BUILD_GENERAL1_MEDIUM',
+      EnvironmentType: 'LINUX_EC2'
+    });
+
+    // Assert that the stack creates a KMS key
+    template.hasResourceProperties('AWS::KMS::Key', {
+      Description: 'Kms Key to encrypt data-at-rest',
+      Enabled: true
+    });
+
+    // Assert that the stack creates a KMS alias
+    template.hasResourceProperties('AWS::KMS::Alias', {
+      AliasName: Match.stringLikeRegexp('alias/finch-x86_64_ubuntu-kms-us-west-2')
+    });
+
+    // Check resource count
+    template.resourceCountIs('AWS::CodeBuild::Project', 1);
+    template.resourceCountIs('AWS::CodeBuild::Fleet', 1);
+    template.resourceCountIs('AWS::KMS::Key', 1);
+  });
+});

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,10 @@
+import { toStackName } from "../lib/utils";
+
+describe('toStackName', () => {
+    test('should return a string with the correct format', () => {
+        const name = 'CodebuildStack-x86_64_ubuntu';
+        const expected = 'CodebuildStack-x86-64-ubuntu';
+        const actual = toStackName(name);
+        expect(actual).toBe(expected);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "experimentalDecorators": true,
     "strictPropertyInitialization": false,
     "resolveJsonModule": true,
+    "outDir": "./dist",
   },
   "exclude": [
     "node_modules",


### PR DESCRIPTION
*Description of changes:*
 - Implemented a CodeBuild stack that supports Linux, Mac, and Windows AMI build images. 
 - Added two Ubuntu CodeBuild stacks to the pipeline, one for each arch (`x86_64` and `arm64`)

*Testing done:*
`npm run test`


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
