### PR TITLE
fix: CodeBuild access token secret and update GitHub source fields

### DIFF
--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -26,7 +26,9 @@ const githHubSource = codebuild.Source.gitHub({
   owner: 'runfinch',
   repo: 'finch',
   webhook: true,
-  webhookFilters: webhookFiltersArr
+  webhookFilters: webhookFiltersArr,
+  fetchSubmodules: true,
+  cloneDepth: 0,
 });
 
 interface ImageFilterProps {
@@ -91,7 +93,7 @@ export class CodeBuildStack extends cdk.Stack {
     });
 
     new codebuild.GitHubSourceCredentials(this, `code-build-${platformId}-credentials`, {
-      accessToken: cdk.SecretValue.secretsManager(secretArn)
+      accessToken: cdk.SecretValue.secretsManager('codebuild-github-access-token')
     });
 
     const machineImageProps = {


### PR DESCRIPTION
*Issue #, if available:*
- Secret was improperly formatted, causing the pipeline to fail. CodeBuild just needed the secret name, not the ARN

*Description of changes:*


*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
