### PR TITLE
fix: CodeBuild secert multiple instantiation

### DIFF
--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -92,10 +92,6 @@ export class CodeBuildStack extends cdk.Stack {
       arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME
     });
 
-    new codebuild.GitHubSourceCredentials(this, `code-build-${platformId}-credentials`, {
-      accessToken: cdk.SecretValue.secretsManager('codebuild-github-access-token')
-    });
-
     const machineImageProps = {
       name: props.amiSearchString,
       filters: {

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -1,5 +1,6 @@
 import * as cdk from 'aws-cdk-lib';
 import { CfnOutput } from 'aws-cdk-lib';
+import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import * as ecr from 'aws-cdk-lib/aws-ecr';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import { Construct } from 'constructs';
@@ -85,6 +86,13 @@ export class FinchPipelineAppStage extends cdk.Stage {
     new SSMPatchingStack(this, 'SSMPatchingStack', { terminationProtection: true });
 
     // Create Ubuntu Codebuild projects for each arch
+    // CodeBuild credentials are account-wide, so creating them multiple times within the for
+    // loop causes an error.
+    // TODO: refactor CodeBuildStack into CodeBuildProjects and loop inside of the constructor.
+    new codebuild.GitHubSourceCredentials(this, `code-build-credentials`, {
+      accessToken: cdk.SecretValue.secretsManager('codebuild-github-access-token')
+    });
+
     for (const { arch, operatingSystem, amiSearchString, environmentType, buildImageOS } of CODEBUILD_STACKS) {
       new CodeBuildStack(this, `CodeBuildStack-${operatingSystem}-${toStackName(arch)}`, {
         env: props.env,

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -89,9 +89,14 @@ export class FinchPipelineAppStage extends cdk.Stage {
     // CodeBuild credentials are account-wide, so creating them multiple times within the for
     // loop causes an error.
     // TODO: refactor CodeBuildStack into CodeBuildProjects and loop inside of the constructor.
-    new codebuild.GitHubSourceCredentials(this, `code-build-credentials`, {
-      accessToken: cdk.SecretValue.secretsManager('codebuild-github-access-token')
-    });
+    new (class CodeBuildCredentialsStack extends cdk.Stack {
+      constructor(scope: Construct, id: string) {
+        super(scope, id, props);
+            new codebuild.GitHubSourceCredentials(this, `code-build-credentials`, {
+              accessToken: cdk.SecretValue.secretsManager('codebuild-github-access-token')
+            });
+        }
+    })(this, "CodeBuildStack-credentials");
 
     for (const { arch, operatingSystem, amiSearchString, environmentType, buildImageOS } of CODEBUILD_STACKS) {
       new CodeBuildStack(this, `CodeBuildStack-${operatingSystem}-${toStackName(arch)}`, {


### PR DESCRIPTION
*Issue #, if available:*
CodeBuild credentials are account-wide, so creating them multiple times causes an error

*Description of changes:*
- Moved CodeBuild credential creation outside of for loop

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
