### PR TITLE
fix: enable termination protection for codebuild fleet

### DIFF
--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -55,6 +55,7 @@ class CodeBuildStackDefaultProps {
   static readonly projectEnvironmentProps = {
     computeType: codebuild.ComputeType.MEDIUM
   };
+  static readonly terminationProtection: boolean = true;
 }
 
 class CodeBuildStackProps {
@@ -78,7 +79,10 @@ class CodeBuildStackProps {
 
 export class CodeBuildStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: CodeBuildStackProps) {
-    super(scope, id, props);
+    super(scope, id, {
+      ...props,
+      terminationProtection: CodeBuildStackDefaultProps.terminationProtection,
+    });
     this.createBuildProject(props, id);
   }
 

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -91,7 +91,10 @@ export class FinchPipelineAppStage extends cdk.Stage {
     // TODO: refactor CodeBuildStack into CodeBuildProjects and loop inside of the constructor.
     const codebuildCredsStack = new (class CodeBuildCredentialsStack extends cdk.Stack {
       constructor(scope: Construct, id: string) {
-        super(scope, id, props);
+        super(scope, id, {
+          ...props,
+          terminationProtection: true,
+        });
         new codebuild.GitHubSourceCredentials(this, `code-build-credentials`, {
           accessToken: cdk.SecretValue.secretsManager('codebuild-github-access-token')
         });


### PR DESCRIPTION
*Description of changes:*
- Enable termination protection for the Codebuild fleet by setting the `DisableApiTermination` to true, as suggested by the [AWS Docs](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_ChangingDisableAPITermination.html)

*Testing done:*
`npm run test`


- [X] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
