### PR TITLE
feat: add mac instances in codebuild project

### DIFF
--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -31,6 +31,15 @@ const githHubSource = codebuild.Source.gitHub({
   cloneDepth: 0,
 });
 
+const githHubSourceDaemon = codebuild.Source.gitHub({
+  owner: 'runfinch',
+  repo: 'finch-daemon',
+  webhook: true,
+  webhookFilters: webhookFiltersArr,
+  fetchSubmodules: true,
+  cloneDepth: 0,
+});
+
 interface ImageFilterProps {
   'virtualization-type': string[];
   'root-device-type': string[];
@@ -59,6 +68,7 @@ class CodeBuildStackDefaultProps {
 }
 
 class CodeBuildStackProps {
+  repo: string;
   env: cdk.Environment | undefined;
   projectName: string;
   region: string;
@@ -72,6 +82,7 @@ class CodeBuildStackProps {
     computeType: codebuild.FleetComputeType;
     baseCapacity: number;
   };
+  buildImageString?: codebuild.IBuildImage;
   projectEnvironmentProps?: {
     computeType: codebuild.ComputeType;
   };
@@ -96,15 +107,6 @@ export class CodeBuildStack extends cdk.Stack {
       arnFormat: cdk.ArnFormat.COLON_RESOURCE_NAME
     });
 
-    const machineImageProps = {
-      name: props.amiSearchString,
-      filters: {
-        ...(props.imageFilterProps || CodeBuildStackDefaultProps.imageFilterProps),
-        architecture: [props.arch]
-      }
-    };
-    const machineImage = new ec2.LookupMachineImage(machineImageProps);
-
     const fleetServiceRole = new iam.Role(this, `FleetServiceRole-${platformId}`, {
       assumedBy: new iam.ServicePrincipal('codebuild.amazonaws.com'),
       managedPolicies: [
@@ -118,19 +120,47 @@ export class CodeBuildStack extends cdk.Stack {
       environmentType: props.environmentType
     });
 
-    const imageId: string = machineImage.getImage(this).imageId;
+    let buildImage: codebuild.IBuildImage;
+    let imageId: string;
+    let githubSource: codebuild.ISource;
+
+    if (!props.amiSearchString) {
+      // For finch-daemon (macOS), use the buildImageString directly
+      buildImage = props.buildImageString!;
+      // Empty string for macOS since we don't need an ImageId
+      imageId = ""; 
+    } else {
+      // For all other projects, look up the AMI
+      const machineImageProps = {
+        name: props.amiSearchString,
+        filters: {
+          ...(props.imageFilterProps || CodeBuildStackDefaultProps.imageFilterProps),
+          architecture: [props.arch]
+        }
+      };
+      const machineImage = new ec2.LookupMachineImage(machineImageProps);
+      imageId = machineImage.getImage(this).imageId;
+      buildImage = this.getBuildImageByOS(props.buildImageOS, props.environmentType, imageId);
+    }
+
+    githubSource = props.repo == "finch-daemon" ? githHubSourceDaemon : githHubSource;
 
     const cfnFleet = fleet.node.defaultChild as cdk.CfnResource;
-    cfnFleet.addPropertyOverride('ImageId', imageId);
+    
+    // Only set ImageId if it's not empty (skip for macOS)
+    if (imageId) {
+      cfnFleet.addPropertyOverride('ImageId', imageId);
+    }
+    
     cfnFleet.addPropertyOverride('FleetServiceRole', fleetServiceRole.roleArn);
 
     const codebuildProject = new codebuild.Project(this, id, {
       projectName: props.projectName,
-      source: githHubSource,
+      source: githubSource,
       environment: {
         ...(props.projectEnvironmentProps || CodeBuildStackDefaultProps.projectEnvironmentProps),
         fleet: fleet,
-        buildImage: this.getBuildImageByOS(props.buildImageOS, props.environmentType, imageId)
+        buildImage: buildImage
       },
       encryptionKey: new Key(this, `codebuild-${platformId}-key-${props.region}`, {
         description: 'Kms Key to encrypt data-at-rest',

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -101,18 +101,22 @@ export class FinchPipelineAppStage extends cdk.Stage {
       }
     })(this, 'CodeBuildStack-credentials');
 
-    for (const { arch, operatingSystem, amiSearchString, environmentType, buildImageOS } of CODEBUILD_STACKS) {
-      const codeBuildStack = new CodeBuildStack(this, `CodeBuildStack-${operatingSystem}-${toStackName(arch)}`, {
+    for (const { project, arch, operatingSystem, amiSearchString, environmentType, buildImageOS, buildImageString, fleetProps, projectEnvironmentProps } of CODEBUILD_STACKS) {
+      let codeBuildStack;
+      codeBuildStack = new CodeBuildStack(this, `CodeBuildStack-${operatingSystem}-${toStackName(arch)}`, {
+        repo: project,
         env: props.env,
-        projectName: `finch-${arch}-${props.environmentStage}-instance`,
+        projectName: `${project}-${arch}-${props.environmentStage}-instance`,
         region: 'us-west-2',
         arch,
         amiSearchString,
         operatingSystem,
         buildImageOS: buildImageOS,
-        environmentType: environmentType
+        environmentType: environmentType,
+        buildImageString,
+        fleetProps,
+        projectEnvironmentProps
       });
-
       codeBuildStack.addDependency(codebuildCredsStack);
     }
   }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -7,15 +7,25 @@ export enum BuildImageOS {
 }
 
 export interface CodeBuildStackArgs {
+  project: string;
   operatingSystem: string;
   arch: string;
   amiSearchString: string;
   environmentType: codebuild.EnvironmentType;
   buildImageOS: BuildImageOS;
+  fleetProps?: {
+    computeType: codebuild.FleetComputeType;
+    baseCapacity: number;
+  };
+  buildImageString?: codebuild.IBuildImage,
+  projectEnvironmentProps?: {
+    computeType: codebuild.ComputeType;
+  };
 }
 
 export const CODEBUILD_STACKS: CodeBuildStackArgs[] = [
   {
+    project: 'finch',
     operatingSystem: 'ubuntu',
     arch: 'x86_64',
     amiSearchString: 'ubuntu/images/hvm-ssd/ubuntu*22.04*',
@@ -23,11 +33,21 @@ export const CODEBUILD_STACKS: CodeBuildStackArgs[] = [
     buildImageOS: BuildImageOS.LINUX
   },
   {
+    project: 'finch',
     operatingSystem: 'ubuntu',
     arch: 'arm64',
     amiSearchString: 'ubuntu/images/hvm-ssd/ubuntu*22.04*',
     environmentType: codebuild.EnvironmentType.ARM_EC2,
     buildImageOS: BuildImageOS.LINUX
+  },
+  {
+    project: 'finch-daemon',
+    operatingSystem: 'macOS',
+    arch: 'arm64',
+    amiSearchString: "", // Empty string since we're using buildImageString directly
+    environmentType: codebuild.EnvironmentType.MAC_ARM,
+    buildImageOS: BuildImageOS.MAC,
+    buildImageString: codebuild.MacBuildImage.BASE_14
   }
 ];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^29.5.14",
         "@types/node": "^22.15.30",
         "@types/prettier": "3.0.0",
-        "aws-cdk": "^2.1018.1",
+        "aws-cdk": "^2.1020.2",
         "jest": "^29.7.0",
         "prettier": "^3.5.3",
         "ts-jest": "^29.4.0",
@@ -1363,11 +1363,10 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/aws-cdk": {
-      "version": "2.1018.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1018.1.tgz",
-      "integrity": "sha512-kFPRox5kSm+ktJ451o0ng9rD+60p5Kt1CZIWw8kXnvqbsxN2xv6qbmyWSXw7sGVXVwqrRKVj+71/JeDr+LMAZw==",
+      "version": "2.1020.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1020.2.tgz",
+      "integrity": "sha512-yWdt3dJh4aPm1VNyEgfG3lozGrvddw0i7avt+Cl9KOYixmisQtAg39/aZqzVVqjzVZVEanXmz+tlhzzh75Z69A==",
       "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "cdk": "bin/cdk"
       },
@@ -5584,9 +5583,9 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-cdk": {
-      "version": "2.1018.1",
-      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1018.1.tgz",
-      "integrity": "sha512-kFPRox5kSm+ktJ451o0ng9rD+60p5Kt1CZIWw8kXnvqbsxN2xv6qbmyWSXw7sGVXVwqrRKVj+71/JeDr+LMAZw==",
+      "version": "2.1020.2",
+      "resolved": "https://registry.npmjs.org/aws-cdk/-/aws-cdk-2.1020.2.tgz",
+      "integrity": "sha512-yWdt3dJh4aPm1VNyEgfG3lozGrvddw0i7avt+Cl9KOYixmisQtAg39/aZqzVVqjzVZVEanXmz+tlhzzh75Z69A==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@types/jest": "^29.5.14",
     "@types/node": "^22.15.30",
     "@types/prettier": "3.0.0",
-    "aws-cdk": "^2.1018.1",
+    "aws-cdk": "^2.1020.2",
     "jest": "^29.7.0",
     "prettier": "^3.5.3",
     "ts-jest": "^29.4.0",

--- a/test/codebuild-stack.test.ts
+++ b/test/codebuild-stack.test.ts
@@ -9,6 +9,7 @@ describe('CodeBuildStack', () => {
   test('synthesizes the way we expect', () => {
     const app = new cdk.App();
     const codebuildStackArgs: CodeBuildStackArgs = {
+      project: 'finch',
       operatingSystem: 'ubuntu',
       arch: 'x86_64',
       amiSearchString: 'ubuntu*22.04*',
@@ -21,7 +22,8 @@ describe('CodeBuildStack', () => {
         account: '123456789012',
         region: 'us-east-1'
       },
-      projectName: 'test-project',
+      projectName: codebuildStackArgs.project,
+      repo: codebuildStackArgs.project,
       region: 'us-west-2',
       ...codebuildStackArgs
     });
@@ -38,7 +40,8 @@ describe('CodeBuildStack', () => {
           account: '123456789012',
           region: 'us-east-1'
         },
-        projectName: 'test-project',
+        projectName: codebuildStackArgs.project,
+        repo: codebuildStackArgs.project,
         region: 'us-west-2',
         ...codebuildStackArgs
       });
@@ -50,27 +53,49 @@ describe('CodeBuildStack', () => {
 });
 
 const validateTemplate = (codebuildStack: CodeBuildStackArgs, template: Template) => {
-  // Assert that the stack creates a Fleet
+  let imageMatcher;
+  if (codebuildStack.amiSearchString === "") {
+    // For macOS builds, match only the base image versions (14 or 15)
+    imageMatcher = Match.stringLikeRegexp('aws/codebuild/macos-arm-base:1[45]$');
+  } else {
+    // For regular builds, expect an AMI ID
+    imageMatcher = Match.stringLikeRegexp('ami-1234');
+  }
+
+  // Assert that the stack creates a Project
   template.hasResourceProperties('AWS::CodeBuild::Project', {
-    Name: 'test-project',
+    Name: codebuildStack.project,
     Environment: {
       Type: codebuildStack.environmentType,
-      ComputeType: 'BUILD_GENERAL1_MEDIUM',
-      Image: Match.stringLikeRegexp('ami-1234'),
+      ComputeType: codebuildStack.projectEnvironmentProps?.computeType || 'BUILD_GENERAL1_MEDIUM',
+      Image: imageMatcher,
     },
     Source: {
       Type: 'GITHUB',
-      Location: 'https://github.com/runfinch/finch.git',
+      Location: codebuildStack.project === 'finch-daemon' 
+        ? 'https://github.com/runfinch/finch-daemon.git'
+        : 'https://github.com/runfinch/finch.git',
       ReportBuildStatus: true
     }
   });
 
   // Assert that the stack creates a Fleet
-  template.hasResourceProperties('AWS::CodeBuild::Fleet', {
-    BaseCapacity: 1,
-    ComputeType: 'BUILD_GENERAL1_MEDIUM',
-    EnvironmentType: codebuildStack.environmentType
-  });
+  if (codebuildStack.amiSearchString !== "") {
+    // For non-macOS builds, expect ImageId property
+    template.hasResourceProperties('AWS::CodeBuild::Fleet', {
+      BaseCapacity: codebuildStack.fleetProps?.baseCapacity || 1,
+      ComputeType: codebuildStack.fleetProps?.computeType || 'BUILD_GENERAL1_MEDIUM',
+      EnvironmentType: codebuildStack.environmentType,
+      ImageId: Match.anyValue()
+    });
+  } else {
+    // For macOS builds, ImageId property should not be present
+    template.hasResourceProperties('AWS::CodeBuild::Fleet', {
+      BaseCapacity: codebuildStack.fleetProps?.baseCapacity || 1,
+      ComputeType: codebuildStack.fleetProps?.computeType || 'BUILD_GENERAL1_MEDIUM',
+      EnvironmentType: codebuildStack.environmentType
+    });
+  }
 
   // Assert that the stack creates a Fleet service role
   template.hasResourceProperties('AWS::IAM::Role', {


### PR DESCRIPTION
*Issue #, if available:*
This PR adds changes to provison mac host codebuild runners for the finch-daemon project. 

*Description of changes:*
This will 
- provision a fleet with 
- - *One* Apple M2 (8 vCPUs, 24GiB memory)
- create a codebuild project with github source as the runfinch/finch-daemon repository
- enable us to run finch-daemon tests within the finch vm on each new PR

*Testing done:*
- Updated codebuild-stack.tests.ts with appropriate tests



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
