### PR TITLE
fix: Add SM permission to codebuild fleet service role

### DIFF
--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -113,6 +113,14 @@ export class CodeBuildStack extends cdk.Stack {
       ]
     });
 
+    // Add Secrets Manager permissions to the fleet service role
+    fleetServiceRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [secretArn]
+      })
+    );
+
     const fleet = new codebuild.Fleet(this, `Fleet-${toStackName(props.arch)}`, {
       ...(props.fleetProps || CodeBuildStackDefaultProps.fleetProps),
       environmentType: props.environmentType
@@ -139,12 +147,6 @@ export class CodeBuildStack extends cdk.Stack {
       })
     });
 
-    codebuildProject.addToRolePolicy(
-      new iam.PolicyStatement({
-        actions: ['secretsmanager:GetSecretValue'],
-        resources: [secretArn]
-      })
-    );
 
     return codebuildProject;
   }


### PR DESCRIPTION
*Issue #, if available:*

Resolves IAM permission error during stack updates where the fleet service role couldn't access the GitHub access token secret needed for webhook operations.

*Description of changes:*


*Testing done:*

- Deployed to personal account and ran two updates via cdk on the created stack

- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
