### PR TITLE
fix: Add SM permission to codebuild project

### DIFF
--- a/lib/codebuild-stack.ts
+++ b/lib/codebuild-stack.ts
@@ -147,6 +147,13 @@ export class CodeBuildStack extends cdk.Stack {
       })
     });
 
+    // Add Secrets Manager permissions to the CodeBuild project role for webhook operations
+    codebuildProject.addToRolePolicy(
+      new iam.PolicyStatement({
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [secretArn]
+      })
+    );
 
     return codebuildProject;
   }


### PR DESCRIPTION
*Issue #, if available:*
- seems that the codebuild project policy is required for the first time creation of the webhook, adding it back

*Description of changes:*


*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
