### PR TITLE
ci: adjust runner number to true limit

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -54,7 +54,7 @@ export const CODEBUILD_STACKS: CodeBuildStackArgs[] = [
     buildImageString: codebuild.MacBuildImage.BASE_14,
     fleetProps: {
       computeType: codebuild.FleetComputeType.MEDIUM,
-      baseCapacity: 5 // ideally 8, but capped at 5
+      baseCapacity: 4 // ideally 8, but capped
     },
   }
 ];


### PR DESCRIPTION
*Description of changes:* Increased number of CodeBuild ARM runners for finch-daemon to 4 to account for SAMcli tests.

*Testing done:* It seems that 4 runners is the limit for this type.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
