### PR TITLE
ci: increase mac runners under envProd account

### DIFF
--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -14,7 +14,7 @@ import { ECRRepositoryStack } from './ecr-repo-stack';
 import { EventBridgeScanNotifsStack } from './event-bridge-scan-notifs-stack';
 import { PVREReportingStack } from './pvre-reporting-stack';
 import { SSMPatchingStack } from './ssm-patching-stack';
-import { CODEBUILD_STACKS, toStackName } from './utils';
+import { getCodeBuildStacks, toStackName } from './utils';
 
 export enum ENVIRONMENT_STAGE {
   Beta,
@@ -101,7 +101,7 @@ export class FinchPipelineAppStage extends cdk.Stage {
       }
     })(this, 'CodeBuildStack-credentials');
 
-    for (const { project, arch, operatingSystem, amiSearchString, environmentType, buildImageOS, buildImageString, fleetProps, projectEnvironmentProps } of CODEBUILD_STACKS) {
+    for (const { project, arch, operatingSystem, amiSearchString, environmentType, buildImageOS, buildImageString, fleetProps, projectEnvironmentProps } of getCodeBuildStacks(props.env?.account)) {
       let codeBuildStack;
       codeBuildStack = new CodeBuildStack(this, `CodeBuildStack-${operatingSystem}-${toStackName(arch)}`, {
         repo: project,

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,4 +1,15 @@
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
+import { EnvConfig } from '../config/env-config';
+
+// Increasing capacity only for release account, keeping intermediates at 1
+export const getMacBaseCapacityForAccount = (accountId?: string): number => {
+  switch (accountId) {
+    case EnvConfig.envRelease.account:
+      return 3;
+    default:
+      return 1;
+  }
+};
 
 export enum BuildImageOS {
   LINUX = 'linux',
@@ -23,7 +34,10 @@ export interface CodeBuildStackArgs {
   };
 }
 
-export const CODEBUILD_STACKS: CodeBuildStackArgs[] = [
+/**
+ * Get CodeBuild stacks configuration with account-specific capacity
+ */
+export const getCodeBuildStacks = (accountId?: string): CodeBuildStackArgs[] => [
   {
     project: 'finch',
     operatingSystem: 'ubuntu',
@@ -54,10 +68,13 @@ export const CODEBUILD_STACKS: CodeBuildStackArgs[] = [
     buildImageString: codebuild.MacBuildImage.BASE_14,
     fleetProps: {
       computeType: codebuild.FleetComputeType.MEDIUM,
-      baseCapacity: 5 // ideally 8, but capped at 5
+      baseCapacity: getMacBaseCapacityForAccount(accountId)
     },
   }
 ];
+
+// Create const with default configuration for backwards compatibility
+export const CODEBUILD_STACKS: CodeBuildStackArgs[] = getCodeBuildStacks();
 
 // members of the runfinch org (+dependabot)
 // curl -s https://api.github.com/users/<username> | jq '.id'

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,10 +1,11 @@
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import { EnvConfig } from '../config/env-config';
 
-// Increasing capacity only for release account, keeping intermediates at 1
 export const getMacBaseCapacityForAccount = (accountId?: string): number => {
   switch (accountId) {
     case EnvConfig.envRelease.account:
+      return 3;
+    case EnvConfig.envProd.account:
       return 3;
     default:
       return 1;


### PR DESCRIPTION
*Description of changes:* Allowing prod account 090529234398 to have access to 3 mac runners. It currently has access to 1 runner, which is able to be picked up through GitHub Actions (though is still showing some issues). 

*Testing done:* We do not know whether this account has a high enough c-score for this increase to be successful. This merge will show us whether this is possible, and we can act accordingly.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
