### PR TITLE
Move patching to 6am UTC

### DIFF
--- a/lib/ssm-patching-stack.ts
+++ b/lib/ssm-patching-stack.ts
@@ -13,8 +13,8 @@ export class SSMPatchingStack extends cdk.Stack {
       allowUnassociatedTargets: false,
       cutoff: 0,
       duration: 2,
-      // Every day at 8 AM UTC
-      schedule: 'cron(0 8 ? * * *)'
+      // Every day at 6 AM UTC
+      schedule: 'cron(0 6 ? * * *)'
     });
 
     const maintenanceTarget = new CfnMaintenanceWindowTarget(this, 'MaintenanceWindowTarget', {

--- a/test/ssm-patching-stack.test.ts
+++ b/test/ssm-patching-stack.test.ts
@@ -15,7 +15,7 @@ describe('SSMPatchingStack', () => {
         Cutoff: 0,
         Duration: 2,
         Name: 'Patching-Window',
-        Schedule: 'cron(0 8 ? * * *)'
+        Schedule: 'cron(0 6 ? * * *)'
       }
     });
 


### PR DESCRIPTION

*Issue #, if available:*
N/A

*Description of changes:*
Many of the scheduled jobs in finch and finch-daemon run at 9am UTC. Often, patching takes 1-2 hours and takes down a host that's being used for a scheduled job which causes failures.

This change moves patching 2 hours earlier to try to avoid overlapping.


*Testing done:*



- [ ] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
