### PR TITLE
fix: firewall rule configured on windows runner reboot

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -126,9 +126,34 @@ tasks:
           Start-Process msiexec.exe -Wait -ArgumentList '/i C:\Users\Administrator\setup\wsl_update_x64.msi /L*V C:\WSLInstallation.log /quiet'
           Exit-ASStandby -AutoScalingGroupName $ASGName -InstanceId $InstanceId
           Add-MpPreference -ExclusionPath "C:\Users\ADMINI~1\AppData\Local\Temp\go-build*" -Force
-          Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath wsl -ArgumentList '--install Ubuntu' }
-          sleep 30 # sleep to allow Ubuntu VM to start
-          New-NetFirewallRule -DisplayName "WSL" -Direction Inbound -InterfaceAlias "vEthernet (WSL)" -Action Allow
+          $job = Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath wsl -ArgumentList '--install Ubuntu' -PassThru }
+          Write-Information "Waiting for vEthernet (WSL) interface to be created..."
+          $waitStart = Get-Date
+          $maxWait = 120
+          while (!(Get-NetAdapter -Name "vEthernet (WSL)" -ErrorAction SilentlyContinue)) {
+              if ($job.State -eq 'Failed') {
+                  Write-Error "WSL job failed: $(Receive-Job -Job $job 2>&1)"
+                  break
+              }
+              if (((Get-Date) - $waitStart).TotalSeconds -gt $maxWait) {
+                  Write-Error "Timeout waiting for vEthernet (WSL) interface after $maxWait seconds"
+                  break
+              }
+              Start-Sleep -Seconds 5
+          }
+          $waitTime = (Get-Date) - $waitStart
+          Write-Information "vEthernet (WSL) interface detected after $($waitTime.TotalSeconds) seconds, creating firewall rule..."
+          if (Get-NetAdapter -Name "vEthernet (WSL)" -ErrorAction SilentlyContinue) {
+              New-NetFirewallRule -DisplayName "WSL" -Direction Inbound -InterfaceAlias "vEthernet (WSL)" -Action Allow -ErrorAction Stop
+              $rule = Get-NetFirewallRule -DisplayName "WSL" -ErrorAction SilentlyContinue
+              if ($rule) {
+                  Write-Information "Firewall rule created successfully. Rule ID: $($rule.Name)"
+              } else {
+                  Write-Error "Firewall rule creation command succeeded but rule not found in firewall."
+              }
+          } else {
+              Write-Error "vEthernet (WSL) interface not found, skipping firewall rule creation."
+          }
           '@
 
           # Write startup powershell script to file. 


### PR DESCRIPTION
*Description of changes:* Change user data script for Windows runners to wait for interface to become available rather than just sleep for 30 seconds before trying to apply firewall script. The goal is to make firewall rule exist on instance reboot and remove need for manual intervention for [host-to-IP mapping test errors](https://w.amazon.com/bin/view/Finch/Runbook/Windows#HFixhost-to-IPmappingtesterrors).

*Testing done:* I tested on my own Windows instance with a more minimal test script (higher maxWait but that is irrelevant):
```
version: 1.0
tasks:
  - task: executeScript
    inputs:
      - frequency: once
        type: powershell
        runAs: admin
        content: |-
          Start-Transcript -Path "C:\UserData.log" -Append
          
          Write-Information "Installing WSL..."
          wsl --install
          
          Write-Information "Creating startup script for post-reboot..."
          $startupscript = @'
          Start-Transcript -Path "C:\StartupScript.log" -Append
          $job = Start-Job -ScriptBlock { Start-Process -NoNewWindow -FilePath wsl -ArgumentList '--install Ubuntu' -PassThru }
          Write-Information "Waiting for vEthernet (WSL) interface to be created..."
          $waitStart = Get-Date
          $maxWait = 300
          while (!(Get-NetAdapter -Name "vEthernet (WSL)" -ErrorAction SilentlyContinue)) {
              if ($job.State -eq 'Failed') {
                  Write-Error "WSL job failed: $(Receive-Job -Job $job 2>&1)"
                  break
              }
              if (((Get-Date) - $waitStart).TotalSeconds -gt $maxWait) {
                  Write-Error "Timeout waiting for vEthernet (WSL) interface after $maxWait seconds"
                  break
              }
              Start-Sleep -Seconds 5
          }
          $waitTime = (Get-Date) - $waitStart
          Write-Information "vEthernet (WSL) interface detected after $($waitTime.TotalSeconds) seconds, creating firewall rule..."
          New-NetFirewallRule -DisplayName "WSL-Test" -Direction Inbound -InterfaceAlias "vEthernet (WSL)" -Action Allow
          Write-Information "Firewall rule created successfully."
          Get-NetFirewallRule -DisplayName "WSL-Test"
          '@
          
          Set-Content 'C:\startup.ps1' $startupscript
          
          $trigger = New-JobTrigger -AtStartup -RandomDelay 00:00:30
          Register-ScheduledJob -Trigger $trigger -FilePath C:\startup.ps1 -Name test-firewall-fix
          
          Write-Information "Restarting instance..."
          Restart-Computer

```
After reboot, with SSM in instance we observe the following, showing that the firewall rule persisted:
```
PS C:\Windows\system32> Get-Content C:\StartupScript.log
**********************
Windows PowerShell transcript start
Start time: 20260218231055
Username: EC2AMAZ-FC3BOIK\Administrator
RunAs User: EC2AMAZ-FC3BOIK\Administrator
Configuration Name:
Machine: EC2AMAZ-FC3BOIK (Microsoft Windows NT 10.0.20348.0)
Host Application: C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Version 5.1 -s -NoLogo -NoProfile
Process ID: 7116
PSVersion: 5.1.20348.4294
PSEdition: Desktop
PSCompatibleVersions: 1.0, 2.0, 3.0, 4.0, 5.0, 5.1.20348.4294
BuildVersion: 10.0.20348.4294
CLRVersion: 4.0.30319.42000
WSManStackVersion: 3.0
PSRemotingProtocolVersion: 2.3
SerializationVersion: 1.1.0.1
**********************
INFO: Waiting for vEthernet (WSL) interface to be created...
INFO: vEthernet (WSL) interface detected after 12.702282 seconds, creating firewall rule...
INFO: Firewall rule created successfully.
PS C:\Windows\system32>
PS C:\Windows\system32> Get-NetFirewallRule -DisplayName "WSL-Test"


Name                          : {3e08b050-d82d-4114-861c-946cdadbc4f6}
DisplayName                   : WSL-Test
Description                   :
DisplayGroup                  :
Group                         :
Enabled                       : True
Profile                       : Any
Platform                      : {}
Direction                     : Inbound
Action                        : Allow
EdgeTraversalPolicy           : Block
LooseSourceMapping            : False
LocalOnlyMapping              : False
Owner                         :
PrimaryStatus                 : OK
Status                        : The rule was parsed successfully from the store. (65536)
EnforcementStatus             : NotApplicable
PolicyStoreSource             : PersistentStore
PolicyStoreSourceType         : Local
RemoteDynamicKeywordAddresses : {}
PolicyAppId                   :
```

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
