### PR TITLE
feat: onboard to inspector watcher

### DIFF
--- a/lib/event-bridge-scan-notifs-stack.ts
+++ b/lib/event-bridge-scan-notifs-stack.ts
@@ -1,6 +1,7 @@
 import * as cdk from 'aws-cdk-lib';
 import * as events from 'aws-cdk-lib/aws-events';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as inspectorv2 from 'aws-cdk-lib/aws-inspectorv2';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as sns from 'aws-cdk-lib/aws-sns';
 import * as subscriptions from 'aws-cdk-lib/aws-sns-subscriptions';
@@ -26,7 +27,7 @@ export class EventBridgeScanNotifsStack extends cdk.Stack {
       runtime: lambda.Runtime.PYTHON_3_11,
       handler: 'main.lambda_handler',
       code: lambda.Code.fromAsset(path.join(__dirname, 'image-scanning-notifications-lambda-handler')),
-      environment: {'SNS_ARN': topic.topicArn,},
+      environment: { 'SNS_ARN': topic.topicArn, },
     });
 
     const snsTopicPolicy = new iam.PolicyStatement({
@@ -35,20 +36,43 @@ export class EventBridgeScanNotifsStack extends cdk.Stack {
     });
 
     notificationFn.addToRolePolicy(snsTopicPolicy);
-    
+
+    const latestAmd64Tag = 'latest-x86-64';
+    const latestArm64Tag = 'latest-arm64';
+
     // Only publish CRITICAL and HIGH findings (more than 7.0 CVE score) that are ACTIVE
+    // and are from images tagged with either 'latest-amd64' or 'latest-arm64'.
     // https://docs.aws.amazon.com/inspector/latest/user/findings-understanding-severity.html
     const rule = new events.Rule(this, 'rule', {
-        eventPattern: {
-          source: ['aws.inspector2'],
-          detail: {
-            severity: ['HIGH', 'CRITICAL'], 
-            status: events.Match.exactString('ACTIVE')
+      eventPattern: {
+        source: ['aws.inspector2'],
+        detail: {
+          severity: ['HIGH', 'CRITICAL'],
+          status: events.Match.exactString('ACTIVE'),
+          resources: {
+            details: {
+              awsEcrContainerImage: {
+                imageTags: [latestAmd64Tag, latestArm64Tag],
+              },
+            },
           },
-          detailType: events.Match.exactString('Inspector2 Finding'),
         },
-      });
+        detailType: events.Match.exactString('Inspector2 Finding'),
+      },
+    });
 
     rule.addTarget(new targets.LambdaFunction(notificationFn))
+
+    // Suppress inspector findings from images that don't have the latest tags
+    new inspectorv2.CfnFilter(this, 'SuppressNonLatestImageFindings', {
+      filterAction: 'SUPPRESS',
+      name: 'SuppressNonLatestImageFindings',
+      filterCriteria: {
+        ecrImageTags: [
+          { comparison: 'NOT_EQUALS', value: latestAmd64Tag },
+          { comparison: 'NOT_EQUALS', value: latestArm64Tag },
+        ],
+      },
+    });
   }
 }

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -12,6 +12,7 @@ import { CodeBuildStack } from './codebuild-stack';
 import { ContinuousIntegrationStack } from './continuous-integration-stack';
 import { ECRRepositoryStack } from './ecr-repo-stack';
 import { EventBridgeScanNotifsStack } from './event-bridge-scan-notifs-stack';
+import { InspectorWatcherStack } from './inspector-watcher-stack';
 import { PVREReportingStack } from './pvre-reporting-stack';
 import { SSMPatchingStack } from './ssm-patching-stack';
 import { getCodeBuildStacks, toStackName } from './utils';
@@ -74,6 +75,8 @@ export class FinchPipelineAppStage extends cdk.Stage {
       // Only report rootfs image scans in prod to avoid duplicate notifications.
       if (props.environmentStage == ENVIRONMENT_STAGE.Prod) {
         new EventBridgeScanNotifsStack(this, 'EventBridgeScanNotifsStack', this.stageName);
+        // Stack to enable InspectorWatcher to scan os images in our ECR repo.
+        new InspectorWatcherStack(this, 'InspectorWatcherStack', { terminationProtection: true });
       }
 
       new ContinuousIntegrationStack(this, 'FinchContinuousIntegrationStack', this.stageName, {

--- a/lib/inspector-watcher-stack.ts
+++ b/lib/inspector-watcher-stack.ts
@@ -1,0 +1,49 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as ssm from 'aws-cdk-lib/aws-ssm';
+import { Construct } from 'constructs';
+import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-protection';
+
+export class InspectorWatcherStack extends cdk.Stack {
+  constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+    applyTerminationProtectionOnStacks([this]);
+
+    const accountId = ssm.StringParameter.valueForStringParameter(this, '/finch/account/inspector-watcher');
+
+    new iam.Role(this, 'InspectorWatcherReadonly', {
+      roleName: 'InspectorWatcherReadonly',
+      assumedBy: new iam.ArnPrincipal(`arn:aws:iam::${accountId}:root`).withConditions({
+        ArnLike: {
+          'aws:PrincipalArn': `arn:aws:iam::${accountId}:role/InspectorWatcherStack*`,
+        },
+      }),
+      inlinePolicies: {
+        InspectorWatcherReadOnly: new iam.PolicyDocument({
+          statements: [
+            new iam.PolicyStatement({
+              sid: 'InspectorWatcherReadOnly',
+              actions: [
+                'ecr:DescribeImageScanFindings',
+                'ecr:DescribeRegistry',
+                'ecr:BatchGetImage',
+                'ecr:DescribeImages',
+                'ecr:DescribeRepositories',
+                'ecr:ListTagsForResource',
+                'ecr:BatchGetRepositoryScanningConfiguration',
+                'ecr:ListImages',
+                'ecr:GetRegistryScanningConfiguration',
+                'inspector2:BatchGet*',
+                'inspector2:List*',
+                'inspector2:Describe*',
+                'inspector2:Get*',
+                'inspector2:Search*',
+              ],
+              resources: ['*'],
+            }),
+          ],
+        }),
+      },
+    });
+  }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -1,17 +1,11 @@
 import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import { EnvConfig } from '../config/env-config';
 
-// Increasing capacity for chosen accounts
 export const getMacBaseCapacityForAccount = (accountId?: string): number => {
-  switch (accountId) {
-    case EnvConfig.envRelease.account:
-      return 1;
-    case EnvConfig.envProd.account:
-      return 1;
-    default:
-      return 1;
-  }
-};
+  // Account specific configuration has been removed for now,
+  // as we are facing capacity issues with the dedicated mac instances.
+  return 1;
+}
 
 export enum BuildImageOS {
   LINUX = 'linux',
@@ -39,41 +33,62 @@ export interface CodeBuildStackArgs {
 /**
  * Get CodeBuild stacks configuration with account-specific capacity
  */
-export const getCodeBuildStacks = (accountId?: string): CodeBuildStackArgs[] => [
-  {
-    project: 'finch',
-    operatingSystem: 'ubuntu',
-    arch: 'x86_64',
-    amiSearchString: 'ubuntu/images/hvm-ssd-gp3/ubuntu*24.04*',
-    environmentType: codebuild.EnvironmentType.LINUX_EC2,
-    buildImageOS: BuildImageOS.LINUX
-  },
-  {
-    project: 'finch',
-    operatingSystem: 'ubuntu',
-    arch: 'arm64',
-    amiSearchString: 'ubuntu/images/hvm-ssd-gp3/ubuntu*24.04*', // TODO: make this more robust
-    environmentType: codebuild.EnvironmentType.ARM_EC2,
-    buildImageOS: BuildImageOS.LINUX,
-    fleetProps: {
-      computeType: codebuild.FleetComputeType.LARGE,
-      baseCapacity: 1,
-    }
-  },
-  {
-    project: 'finch-daemon',
-    operatingSystem: 'macOS26',
-    arch: 'arm64',
-    amiSearchString: "",
-    environmentType: codebuild.EnvironmentType.MAC_ARM,
-    buildImageOS: BuildImageOS.MAC,
-    buildImageString: codebuild.MacBuildImage.BASE_26,
-    fleetProps: {
-      computeType: codebuild.FleetComputeType.MEDIUM,
-      baseCapacity: getMacBaseCapacityForAccount(accountId)
+export const getCodeBuildStacks = (accountId?: string): CodeBuildStackArgs[] => {
+  const stacks: CodeBuildStackArgs[] = [
+    {
+      project: 'finch',
+      operatingSystem: 'ubuntu',
+      arch: 'x86_64',
+      amiSearchString: 'ubuntu/images/hvm-ssd-gp3/ubuntu*24.04*',
+      environmentType: codebuild.EnvironmentType.LINUX_EC2,
+      buildImageOS: BuildImageOS.LINUX
     },
+    {
+      project: 'finch',
+      operatingSystem: 'ubuntu',
+      arch: 'arm64',
+      amiSearchString: 'ubuntu/images/hvm-ssd-gp3/ubuntu*24.04*', // TODO: make this more robust
+      environmentType: codebuild.EnvironmentType.ARM_EC2,
+      buildImageOS: BuildImageOS.LINUX,
+      fleetProps: {
+        computeType: codebuild.FleetComputeType.LARGE,
+        baseCapacity: 1,
+      }
+    },
+    {
+      project: 'finch-daemon',
+      operatingSystem: 'macOS26',
+      arch: 'arm64',
+      amiSearchString: "",
+      environmentType: codebuild.EnvironmentType.MAC_ARM,
+      buildImageOS: BuildImageOS.MAC,
+      buildImageString: codebuild.MacBuildImage.BASE_26,
+      fleetProps: {
+        computeType: codebuild.FleetComputeType.MEDIUM,
+        baseCapacity: getMacBaseCapacityForAccount(accountId)
+      },
+    }
+  ];
+
+  // Only deploy SAM CLI integration test stack in prod
+  if (accountId === EnvConfig.envProd.account) {
+    stacks.push({
+      project: 'finch',
+      operatingSystem: 'macOS26-samcli',
+      arch: 'arm64',
+      amiSearchString: "",
+      environmentType: codebuild.EnvironmentType.MAC_ARM,
+      buildImageOS: BuildImageOS.MAC as BuildImageOS.MAC,
+      buildImageString: codebuild.MacBuildImage.BASE_26,
+      fleetProps: {
+        computeType: codebuild.FleetComputeType.MEDIUM,
+        baseCapacity: getMacBaseCapacityForAccount(accountId)
+      },
+    })
   }
-];
+
+  return stacks;
+}
 
 // Create const with default configuration for backwards compatibility
 export const CODEBUILD_STACKS: CodeBuildStackArgs[] = getCodeBuildStacks();

--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -21,12 +21,10 @@ if [ "${UNAME_MACHINE}" = "aarch64" ]; then
     GH_RUNNER_ARCH="arm64"
     NODE_DOWNLOAD_ARCH="arm64"
     GH_RUNNER_DOWNLOAD_HASH="b5697062a13f63b44f869de9369638a7039677b9e0f87e47a6001a758c0d09bf"
-    NODE_DOWNLOAD_HASH="e7adfca03d9173276114a6f2219df1a7d25e1bfd6bbd771d3f839118a2053094"
 else
     GH_RUNNER_ARCH="x64"
-    NODE_DOWNLOAD_ARCH="x64"
+    NODE_DOWNLOAD_ARCH="x86_64"
     GH_RUNNER_DOWNLOAD_HASH="7ce6b3fd8f879797fcc252c2918a23e14a233413dc6e6ab8e0ba8768b5d54475"
-    NODE_DOWNLOAD_HASH="41cd79bb7877c81605a9e68ec4c91547774f46a40c67a17e34d7179ef11729df"
 fi
 
 if [ "${OS_NAME}" = "Amazon Linux" ]; then
@@ -36,12 +34,10 @@ if [ "${OS_NAME}" = "Amazon Linux" ]; then
     if [ "${OS_VERSION}" = "2" ]; then
         GH_RUNNER_DEPENDENCIES="openssl krb5-libs zlib jq"
         ADDITIONAL_PACKAGES="policycoreutils-python systemd-rpm-macros inotify-tools ${GH_RUNNER_DEPENDENCIES}"
-        NODE_VERSION="24.14.0"
-        NODE_FILENAME="node-v${NODE_VERSION}-linux-${NODE_DOWNLOAD_ARCH}.tar.xz"
-        curl -LO "https://nodejs.org/dist/v${NODE_VERSION}/${NODE_FILENAME}"
-        echo "${NODE_DOWNLOAD_HASH}  ${NODE_FILENAME}" | sha256sum -c
-        tar -xf "${NODE_FILENAME}"
-        mv "node-v${NODE_VERSION}-linux-${NODE_DOWNLOAD_ARCH}/bin/*" /usr/bin
+        NODE_VERSION="21.2.0"
+        curl -OL "https://d3rnber7ry90et.cloudfront.net/linux-${NODE_DOWNLOAD_ARCH}/node-v${NODE_VERSION}.tar.gz"
+        tar -xf node-v${NODE_VERSION}.tar.gz
+        mv node-v${NODE_VERSION}/bin/* /usr/bin
         # enable EPEL repos, required to install inotify-tools package
         amazon-linux-extras install epel -y
     elif [ "${OS_VERSION}" = "2023" ]; then

--- a/test/inspector-watcher-stack.test.ts
+++ b/test/inspector-watcher-stack.test.ts
@@ -1,0 +1,74 @@
+import * as cdk from 'aws-cdk-lib';
+import { Match, Template } from 'aws-cdk-lib/assertions';
+import { InspectorWatcherStack } from '../lib/inspector-watcher-stack';
+
+describe('InspectorWatcherStack', () => {
+  test('synthesizes the way we expect', () => {
+    const app = new cdk.App();
+    const stack = new InspectorWatcherStack(app, 'InspectorWatcherStack', {
+      terminationProtection: true,
+    });
+
+    const template = Template.fromStack(stack);
+    const ssmParamRef = { 'Ref': Match.stringLikeRegexp('SsmParameterValue.*Parameter') };
+
+    template.resourceCountIs('AWS::IAM::Role', 1);
+    template.hasResource('AWS::IAM::Role', {
+      Properties: {
+        RoleName: 'InspectorWatcherReadonly',
+        AssumeRolePolicyDocument: {
+          Statement: [
+            Match.objectLike({
+              Effect: 'Allow',
+              Principal: {
+                AWS: {
+                  'Fn::Join': ['', ['arn:aws:iam::', ssmParamRef, ':root']],
+                },
+              },
+              Action: 'sts:AssumeRole',
+              Condition: {
+                ArnLike: {
+                  'aws:PrincipalArn': {
+                    'Fn::Join': ['', ['arn:aws:iam::', ssmParamRef, ':role/InspectorWatcherStack*']],
+                  },
+                },
+              },
+            }),
+          ],
+        },
+        Policies: [
+          Match.objectLike({
+            PolicyName: 'InspectorWatcherReadOnly',
+            PolicyDocument: {
+              Statement: [
+                Match.objectLike({
+                  Sid: 'InspectorWatcherReadOnly',
+                  Effect: 'Allow',
+                  Action: [
+                    'ecr:DescribeImageScanFindings',
+                    'ecr:DescribeRegistry',
+                    'ecr:BatchGetImage',
+                    'ecr:DescribeImages',
+                    'ecr:DescribeRepositories',
+                    'ecr:ListTagsForResource',
+                    'ecr:BatchGetRepositoryScanningConfiguration',
+                    'ecr:ListImages',
+                    'ecr:GetRegistryScanningConfiguration',
+                    'inspector2:BatchGet*',
+                    'inspector2:List*',
+                    'inspector2:Describe*',
+                    'inspector2:Get*',
+                    'inspector2:Search*',
+                  ],
+                  Resource: '*',
+                }),
+              ],
+            },
+          }),
+        ],
+      },
+    });
+
+    expect(stack.terminationProtection).toBeTruthy();
+  });
+});


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
- Add stack for inspector watcher.
- Move accounts to ssm params.
- Suppress inspector findings for non-latest images.
- Revert changes to linux runner userdata script.
- Add a codebuild macos stack for samcli.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
