### PR TITLE
ci: fix name of inspector watcher role

### DIFF
--- a/lib/inspector-watcher-stack.ts
+++ b/lib/inspector-watcher-stack.ts
@@ -11,8 +11,8 @@ export class InspectorWatcherStack extends cdk.Stack {
 
     const accountId = ssm.StringParameter.valueForStringParameter(this, '/finch/account/inspector-watcher');
 
-    new iam.Role(this, 'InspectorWatcherReadonly', {
-      roleName: 'InspectorWatcherReadonly',
+    new iam.Role(this, 'InspectorWatcherReadOnly', {
+      roleName: 'InspectorWatcherReadOnly',
       assumedBy: new iam.ArnPrincipal(`arn:aws:iam::${accountId}:root`).withConditions({
         ArnLike: {
           'aws:PrincipalArn': `arn:aws:iam::${accountId}:role/InspectorWatcherStack*`,

--- a/test/inspector-watcher-stack.test.ts
+++ b/test/inspector-watcher-stack.test.ts
@@ -15,7 +15,7 @@ describe('InspectorWatcherStack', () => {
     template.resourceCountIs('AWS::IAM::Role', 1);
     template.hasResource('AWS::IAM::Role', {
       Properties: {
-        RoleName: 'InspectorWatcherReadonly',
+        RoleName: 'InspectorWatcherReadOnly',
         AssumeRolePolicyDocument: {
           Statement: [
             Match.objectLike({


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
The role name must be `InspectorWatcherReadOnly`.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
