### PR TITLE
feat: add ecr batch delete image permission to github action role

### DIFF
--- a/lib/continuous-integration-stack.ts
+++ b/lib/continuous-integration-stack.ts
@@ -59,6 +59,16 @@ export class ContinuousIntegrationStack extends cdk.Stack {
     const repo = props.rootfsEcrRepository;
     repo.grantPullPush(githubActionsRole);
     ecr.AuthorizationToken.grantRead(githubActionsRole)
+    
+    // Permission to delete images from ECR is required by this workflow 
+    // https://github.com/runfinch/finch-core/blob/main/.github/workflows/push-container-image.yaml
+    // to clean up unused os images and reduce aws-inspector generated noise.
+    githubActionsRole.addToPolicy(
+      new iam.PolicyStatement({
+        actions: ['ecr:BatchDeleteImage'],
+        resources: [repo.repositoryArn]
+      })
+    );
 
     new CloudfrontCdn(this, 'DependenciesCloudfrontCdn', {
       bucket


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Adding ECR batch delete image permission for finch's rootfs images repo to github actions role. This is because https://github.com/runfinch/finch-core/blob/main/.github/workflows/push-container-image.yaml needs this permission to clean up old and unused ECR images and suppress AWS inspector noise.

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
