### PR TITLE
fix(ci): change role name for TicketingWebhookSecretAccessRole

### DIFF
--- a/lib/ticketing-webhook-secret-access-stack.ts
+++ b/lib/ticketing-webhook-secret-access-stack.ts
@@ -10,17 +10,18 @@ export class TicketingWebhookSecretAccessStack extends cdk.Stack {
     applyTerminationProtectionOnStacks([this]);
 
     const accountId = ssm.StringParameter.valueForStringParameter(this, '/finch/account/ticketing-webhook');
+    const roleName = ssm.StringParameter.valueForStringParameter(this, '/finch/role/ticketing-webhook-role');
 
     new iam.Role(this, 'TicketingWebhookSecretAccessRole', {
-      roleName: 'TicketingWebhookSecretAccessRole',
+      roleName: roleName,
       assumedBy: new iam.ArnPrincipal(
         `arn:aws:iam::${accountId}:role/ContainerRuntimeGithubTic-ContainerRuntimeGithubTic-QbYIXwNlPv62`
       ),
       inlinePolicies: {
-        TicketingWebhookSecretAccess: new iam.PolicyDocument({
+        SecretsManagerAccess: new iam.PolicyDocument({
           statements: [
             new iam.PolicyStatement({
-              sid: 'TicketingWebhookSecretAccess',
+              sid: 'SecretsManagerAccess',
               actions: ['secretsmanager:GetSecretValue'],
               resources: [`arn:aws:secretsmanager:us-west-2:${cdk.Aws.ACCOUNT_ID}:secret:ticketing-github-webhook-secret*`],
             }),

--- a/test/ticketing-webhook-secret-access-stack.test.ts
+++ b/test/ticketing-webhook-secret-access-stack.test.ts
@@ -15,7 +15,7 @@ describe('TicketingWebhookSecretAccessStack', () => {
     template.resourceCountIs('AWS::IAM::Role', 1);
     template.hasResource('AWS::IAM::Role', {
       Properties: {
-        RoleName: 'TicketingWebhookSecretAccessRole',
+        RoleName: ssmParamRef,
         AssumeRolePolicyDocument: {
           Statement: [
             Match.objectLike({
@@ -38,11 +38,11 @@ describe('TicketingWebhookSecretAccessStack', () => {
         },
         Policies: [
           Match.objectLike({
-            PolicyName: 'TicketingWebhookSecretAccess',
+            PolicyName: 'SecretsManagerAccess',
             PolicyDocument: {
               Statement: [
                 Match.objectLike({
-                  Sid: 'TicketingWebhookSecretAccess',
+                  Sid: 'SecretsManagerAccess',
                   Effect: 'Allow',
                   Action: 'secretsmanager:GetSecretValue',
                   Resource: {


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Ticketing webhook requires the IAM role name to follow a certain pattern. Hence changing the role name.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
