### PR TITLE
ci: add back increased account specific configuration for mac runners

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,10 +2,15 @@ import * as codebuild from 'aws-cdk-lib/aws-codebuild';
 import { EnvConfig } from '../config/env-config';
 
 export const getMacBaseCapacityForAccount = (accountId?: string): number => {
-  // Account specific configuration has been removed for now,
-  // as we are facing capacity issues with the dedicated mac instances.
-  return 1;
-}
+  switch (accountId) {
+    case EnvConfig.envRelease.account:
+      return 3;
+    case EnvConfig.envProd.account:
+      return 3;
+    default:
+      return 1;
+  }
+};
 
 export enum BuildImageOS {
   LINUX = 'linux',


### PR DESCRIPTION
*Description of changes:* Adding back account-level configuration for mac runner capacities to speed up CI.

*Testing done:* NA.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.