### PR TITLE
feat(runners): Add nightly recycle for macOS 26 finch runners

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -266,6 +266,29 @@ export class ASGRunnerStack extends cdk.Stack implements IASGRunnerStack {
         desiredCapacity: 0
       });
     }
+
+    // Nightly recycle for macOS 26 finch runners to prevent
+    // state accumulation that causes runners to become unresponsive.
+    const isMac26Finch =
+      this.platform === PlatformType.MAC &&
+      this.version.startsWith('26') &&
+      this.repo === 'finch';
+
+    if (isMac26Finch) {
+      new autoscaling.CfnScheduledAction(this, 'NightlySpinDown', {
+        autoScalingGroupName: asg.autoScalingGroupName,
+        recurrence: '0 10 * * *', // 10:00 UTC = 2:00 AM PST / 3:00 AM PDT
+        desiredCapacity: 0,
+        minSize: 0
+      });
+
+      new autoscaling.CfnScheduledAction(this, 'NightlySpinUp', {
+        autoScalingGroupName: asg.autoScalingGroupName,
+        recurrence: '30 10 * * *', // 10:30 UTC = 2:30 AM PST / 3:30 AM PDT
+        desiredCapacity: props.type.desiredInstances,
+        minSize: 0
+      });
+    }
   }
 
   // a host resource group is used by the launch template for placement of instances on dedicated hosts


### PR DESCRIPTION
*Description of changes:* Add scheduled ASG actions to spin down and spin up macOS 26 finch self-hosted runners nightly at 10:00/10:30 UTC (2:00/2:30 AM PST). This prevents state accumulation that causes runners to become unresponsive over time, which previously required manual termination to resolve.

This PR only targets these specific runners as they are the only ones frequently becoming unresponsive.

*Testing done:* Ran `npx jest -c ./jest.config.unit.js`:
```
...
Test Suites: 12 passed, 12 total
Tests:       15 passed, 15 total
Snapshots:   0 total
Time:        7.298 s, estimated 14 s
```

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
