### PR TITLE
feat: add finch os build cache repo to ecr

### DIFF
--- a/lib/continuous-integration-stack.ts
+++ b/lib/continuous-integration-stack.ts
@@ -9,6 +9,7 @@ import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-
 
 interface ContinuousIntegrationStackProps extends cdk.StackProps {
   rootfsEcrRepository: ecr.Repository;
+  osBuildCacheEcrRepository: ecr.Repository;
 }
 
 // ContinuousIntegrationStack - AWS stack for supporting Finch's continuous integration process
@@ -59,8 +60,8 @@ export class ContinuousIntegrationStack extends cdk.Stack {
     const repo = props.rootfsEcrRepository;
     repo.grantPullPush(githubActionsRole);
     ecr.AuthorizationToken.grantRead(githubActionsRole)
-    
-    // Permission to delete images from ECR is required by this workflow 
+
+    // Permission to delete images from ECR is required by this workflow
     // https://github.com/runfinch/finch-core/blob/main/.github/workflows/push-container-image.yaml
     // to clean up unused os images and reduce aws-inspector generated noise.
     githubActionsRole.addToPolicy(
@@ -69,6 +70,11 @@ export class ContinuousIntegrationStack extends cdk.Stack {
         resources: [repo.repositoryArn]
       })
     );
+
+    // Add push/pull access to osBuildCacheEcrRepository 
+    // for the github actions role.
+    const osBuildCacheRepo = props.osBuildCacheEcrRepository;
+    osBuildCacheRepo.grantPullPush(githubActionsRole);
 
     new CloudfrontCdn(this, 'DependenciesCloudfrontCdn', {
       bucket

--- a/lib/ecr-repo-stack.ts
+++ b/lib/ecr-repo-stack.ts
@@ -7,6 +7,9 @@ import { applyTerminationProtectionOnStacks } from './aspects/stack-termination-
 export class ECRRepositoryStack extends cdk.Stack {
   public readonly repositoryOutput: CfnOutput;
   public readonly repository: ecr.Repository;
+  public readonly osBuildCacheRepositoryOutput: CfnOutput;
+  public readonly osBuildCacheRepository: ecr.Repository;
+  
   constructor(scope: Construct, id: string, stage: string, props?: cdk.StackProps) {
     super(scope, id, props);
     applyTerminationProtectionOnStacks([this]);
@@ -15,8 +18,8 @@ export class ECRRepositoryStack extends cdk.Stack {
     const ecrRepository = new ecr.Repository(this, 'finch-rootfs', {
         repositoryName:repoName,
         imageTagMutability: ecr.TagMutability.IMMUTABLE,
-        // TODO: CFN does not provide APIs for enhanced image scanning. 
-        // To address, create a custom stack that uses the AWS sdk to change the account ECR 
+        // TODO: CFN does not provide APIs for enhanced image scanning.
+        // To address, create a custom stack that uses the AWS sdk to change the account ECR
         // scanning settings to enhanced.
 
         // For now, scan on image push is set to true. This means that the image will be scanned
@@ -28,5 +31,23 @@ export class ECRRepositoryStack extends cdk.Stack {
 
     this.repository = ecrRepository
     this.repositoryOutput = new CfnOutput(this, 'ECR repository', { value: ecrRepository.repositoryName });
+
+    // This repository is needed to hold build caches for Finch's OS builds.
+    const osBuildCacheRepoName = `finch-os-build-cache-${stage.toLowerCase()}`;
+    const osBuildCacheRepository = new ecr.Repository(this, 'finch-os-build-cache', {
+      repositoryName: osBuildCacheRepoName,
+      imageTagMutability: ecr.TagMutability.MUTABLE,
+      imageScanOnPush: false,
+      lifecycleRules: [
+        {
+          description: 'Expire untagged build cache layers after 30 days',
+          tagStatus: ecr.TagStatus.UNTAGGED,
+          maxImageAge: cdk.Duration.days(30),
+        },
+      ],
+    });
+
+    this.osBuildCacheRepository = osBuildCacheRepository;
+    this.osBuildCacheRepositoryOutput = new CfnOutput(this, 'ECR OS build cache repository', { value: osBuildCacheRepository.repositoryName });
   }
 }

--- a/lib/finch-pipeline-app-stage.ts
+++ b/lib/finch-pipeline-app-stage.ts
@@ -34,6 +34,7 @@ export class FinchPipelineAppStage extends cdk.Stage {
   ecrRepositoryOutput: CfnOutput;
   public readonly cloudfrontBucket: s3.Bucket;
   public readonly ecrRepository: ecr.Repository;
+  public readonly osBuildCacheRepository: ecr.Repository;
 
   constructor(scope: Construct, id: string, props: FinchPipelineAppStageProps) {
     super(scope, id, props);
@@ -72,6 +73,7 @@ export class FinchPipelineAppStage extends cdk.Stage {
 
       this.ecrRepositoryOutput = ecrRepositoryStack.repositoryOutput;
       this.ecrRepository = ecrRepositoryStack.repository;
+      this.osBuildCacheRepository = ecrRepositoryStack.osBuildCacheRepository
 
       // Only report rootfs image scans in prod to avoid duplicate notifications.
       if (props.environmentStage == ENVIRONMENT_STAGE.Prod) {
@@ -83,7 +85,8 @@ export class FinchPipelineAppStage extends cdk.Stage {
       }
 
       new ContinuousIntegrationStack(this, 'FinchContinuousIntegrationStack', this.stageName, {
-        rootfsEcrRepository: this.ecrRepository
+        rootfsEcrRepository: this.ecrRepository,
+        osBuildCacheEcrRepository: this.osBuildCacheRepository,
       });
     }
 

--- a/test/ecr-repo-stack.test.ts
+++ b/test/ecr-repo-stack.test.ts
@@ -10,14 +10,41 @@ describe('ECRRepositoryStack', () => {
     // prepare the ECRRepositoryStack template for assertions
     const template = Template.fromStack(ecrRepo);
 
-    // assert it creates the ecr repo with properties set.
-    template.resourceCountIs('AWS::ECR::Repository', 1);
+    // assert it creates the ecr repos with properties set.
+    template.resourceCountIs('AWS::ECR::Repository', 2);
     template.hasResource('AWS::ECR::Repository', {
       Properties: {
-        RepositoryName: Match.anyValue(),
+        RepositoryName: 'finch-rootfs-image-test',
         ImageTagMutability: "IMMUTABLE",
         ImageScanningConfiguration: {
           ScanOnPush: true,
+        },
+      },
+    });
+
+    template.hasResource('AWS::ECR::Repository', {
+      Properties: {
+        RepositoryName: 'finch-os-build-cache-test',
+        ImageTagMutability: "MUTABLE",
+        ImageScanningConfiguration: {
+          ScanOnPush: false,
+        },
+        LifecyclePolicy: {
+          LifecyclePolicyText: Match.serializedJson({
+            rules: [
+              {
+                rulePriority: 1,
+                selection: {
+                  tagStatus: 'untagged',
+                  countType: 'sinceImagePushed',
+                  countNumber: 30,
+                  countUnit: 'days',
+                },
+                action: { type: 'expire' },
+                description: 'Expire untagged build cache layers after 30 days',
+              },
+            ],
+          }),
         },
       },
     });


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Adds a cache repository to ECR to support buildx caching for Finch's OS builds (https://github.com/runfinch/finch-core/tree/main/deps/mkosi).

*Testing done:*


- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
