### PR TITLE
reduce number of codebuild macos runners

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,9 +4,9 @@ import { EnvConfig } from '../config/env-config';
 export const getMacBaseCapacityForAccount = (accountId?: string): number => {
   switch (accountId) {
     case EnvConfig.envRelease.account:
-      return 3;
+      return 2;
     case EnvConfig.envProd.account:
-      return 3;
+      return 2;
     default:
       return 1;
   }


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*
Codebuild has a default limit of 5 macOS m2.metal runners per account. With 3 runners for finch-daemon and 3 for samcli, we are going beyond the limit in our Prod account. Changing the total to 4 to stay below the limit.

*Testing done:*



- [x] I've reviewed the guidance in CONTRIBUTING.md


#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
