### PR TITLE
feat(runners): Add CloudWatch agent for log shipping on all self-hosted runners

### DIFF
--- a/lib/asg-runner-stack.ts
+++ b/lib/asg-runner-stack.ts
@@ -150,6 +150,7 @@ export class ASGRunnerStack extends cdk.Stack implements IASGRunnerStack {
     role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AmazonSSMManagedInstanceCore'));
     role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('AutoScalingFullAccess'));
     role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('ResourceGroupsandTagEditorFullAccess'));
+    role.addManagedPolicy(iam.ManagedPolicy.fromAwsManagedPolicyName('CloudWatchAgentServerPolicy'));
 
     // Grant EC2 instances access to secretsmanager to retrieve the GitHub api key to register runners
     role.addToPolicy(

--- a/scripts/setup-linux-runner.sh
+++ b/scripts/setup-linux-runner.sh
@@ -182,3 +182,44 @@ cd "${RUNNER_DIR}"
 semanage fcontext -a -t "bin_t" "${RUNNER_DIR}/runsvc.sh"
 ./svc.sh install "${USERNAME}"
 ./svc.sh start
+
+# Install and configure CloudWatch agent for log shipping
+yum install -y amazon-cloudwatch-agent || true
+
+INSTANCE_ID=$(TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << CWEOF
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/messages",
+            "log_group_name": "/ec2/runners/${REPO}/${GH_RUNNER_ARCH}-${DISTRO}-${OS_VERSION}",
+            "log_stream_name": "${INSTANCE_ID}/messages",
+            "retention_in_days": 30
+          },
+          {
+            "file_path": "${RUNNER_DIR}/_diag/Runner_*.log",
+            "log_group_name": "/ec2/runners/${REPO}/${GH_RUNNER_ARCH}-${DISTRO}-${OS_VERSION}",
+            "log_stream_name": "${INSTANCE_ID}/runner-diag",
+            "retention_in_days": 30
+          },
+          {
+            "file_path": "/var/log/setup-runner.log",
+            "log_group_name": "/ec2/runners/${REPO}/${GH_RUNNER_ARCH}-${DISTRO}-${OS_VERSION}",
+            "log_stream_name": "${INSTANCE_ID}/setup-runner",
+            "retention_in_days": 30
+          }
+        ]
+      }
+    }
+  }
+}
+CWEOF
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config \
+  -m ec2 \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json \
+  -s

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -56,3 +56,49 @@ su - ec2-user -c "cd $RUNNER_DIR && ./svc.sh install"
 PLIST_NAME="actions.runner.runfinch-$REPO.$(hostname | cut -d '.' -f 1).plist"
 cp /Users/ec2-user/Library/LaunchAgents/$PLIST_NAME /Library/LaunchDaemons
 /bin/launchctl load /Library/LaunchDaemons/$PLIST_NAME
+
+# Install and configure CloudWatch agent for log shipping
+CW_AGENT_URL="https://amazoncloudwatch-agent.s3.amazonaws.com/darwin/arm64/latest/amazon-cloudwatch-agent.pkg"
+if [ $(arch) != "arm64" ]; then
+  CW_AGENT_URL="https://amazoncloudwatch-agent.s3.amazonaws.com/darwin/amd64/latest/amazon-cloudwatch-agent.pkg"
+fi
+curl -o /tmp/amazon-cloudwatch-agent.pkg -L "$CW_AGENT_URL"
+installer -pkg /tmp/amazon-cloudwatch-agent.pkg -target /
+
+INSTANCE_ID=$(TOKEN=$(curl -s -X PUT http://169.254.169.254/latest/api/token -H "X-aws-ec2-metadata-token-ttl-seconds: 21600") && curl -s -H "X-aws-ec2-metadata-token: $TOKEN" http://169.254.169.254/latest/meta-data/instance-id)
+cat > /opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json << EOF
+{
+  "logs": {
+    "logs_collected": {
+      "files": {
+        "collect_list": [
+          {
+            "file_path": "/var/log/system.log",
+            "log_group_name": "/ec2/runners/${REPO}/${LABEL_ARCH}-${LABEL_VER}",
+            "log_stream_name": "${INSTANCE_ID}/system.log",
+            "retention_in_days": 30
+          },
+          {
+            "file_path": "/Users/ec2-user/ar/_diag/Runner_*.log",
+            "log_group_name": "/ec2/runners/${REPO}/${LABEL_ARCH}-${LABEL_VER}",
+            "log_stream_name": "${INSTANCE_ID}/runner-diag",
+            "retention_in_days": 30
+          },
+          {
+            "file_path": "/Users/ec2-user/setup-runner.log",
+            "log_group_name": "/ec2/runners/${REPO}/${LABEL_ARCH}-${LABEL_VER}",
+            "log_stream_name": "${INSTANCE_ID}/setup-runner",
+            "retention_in_days": 30
+          }
+        ]
+      }
+    }
+  }
+}
+EOF
+
+/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
+  -a fetch-config \
+  -m ec2 \
+  -c file:/opt/aws/amazon-cloudwatch-agent/etc/amazon-cloudwatch-agent.json \
+  -s

--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -156,6 +156,46 @@ tasks:
 
           Invoke-Expression "cmd.exe /c sc config $ServiceName obj= '$(hostname)\Administrator' password= '$GH_KEY' type= own"
 
+          # Install and configure CloudWatch agent for log shipping
+          Write-Information "Installing CloudWatch Agent..."
+          Invoke-WebRequest -Uri 'https://amazoncloudwatch-agent.s3.amazonaws.com/windows/amd64/latest/amazon-cloudwatch-agent.msi' -OutFile 'C:\Users\Administrator\setup\amazon-cloudwatch-agent.msi'
+          Start-Process msiexec.exe -Wait -ArgumentList '/i C:\Users\Administrator\setup\amazon-cloudwatch-agent.msi /quiet'
+
+          $Token = Invoke-RestMethod -Uri http://169.254.169.254/latest/api/token -Method PUT -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"="21600"}
+          $CWInstanceId = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/instance-id -Headers @{"X-aws-ec2-metadata-token"=$Token}
+          $CWConfig = @"
+          {
+            "logs": {
+              "logs_collected": {
+                "files": {
+                  "collect_list": [
+                    {
+                      "file_path": "C:\\actions-runner\\_diag\\Runner_*.log",
+                      "log_group_name": "/ec2/runners/$REPO/amd64-windows",
+                      "log_stream_name": "$CWInstanceId/runner-diag",
+                      "retention_in_days": 30
+                    },
+                    {
+                      "file_path": "C:\\UserData.log",
+                      "log_group_name": "/ec2/runners/$REPO/amd64-windows",
+                      "log_stream_name": "$CWInstanceId/userdata",
+                      "retention_in_days": 30
+                    },
+                    {
+                      "file_path": "C:\\StartupScript.log",
+                      "log_group_name": "/ec2/runners/$REPO/amd64-windows",
+                      "log_stream_name": "$CWInstanceId/startup",
+                      "retention_in_days": 30
+                    }
+                  ]
+                }
+              }
+            }
+          }
+"@
+          Set-Content 'C:\ProgramData\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.json' $CWConfig
+          & 'C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -c file:C:\ProgramData\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.json -s
+
           wsl --install
 
           Write-Information "Restarting instance..."


### PR DESCRIPTION
*Description of changes:* Add CloudWatch agent to all self-hosted runners (macOS, Windows, Linux) to ship system logs and runner diagnostics to CloudWatch Logs. This enables diagnosis of runner failures (e.g., `ConnectionLost`) without requiring SSH/SSM access to the instance.

Logs are available in the account associated with the runner, following a `/ec2/runners/{repo}/{arch}-{version}` format for log group and `{instance-id}/{log-name}` for individual log stream. Logs are retained for 30 days.

*Testing done:* Validated on live instances in prod (`090529234398`, us-west-2) via SSM. All agents started successfully. Log delivery fails only on IAM permissions (this is expected, as `CloudWatchAgentServerPolicy` not yet attached to live role until this deploys). CDK build and unit tests also pass.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.