### PR TITLE
fix(runners): Fix Windows user data YAML parsing error for CloudWatch agent

### DIFF
--- a/scripts/windows-runner-user-data.yaml
+++ b/scripts/windows-runner-user-data.yaml
@@ -163,36 +163,7 @@ tasks:
 
           $Token = Invoke-RestMethod -Uri http://169.254.169.254/latest/api/token -Method PUT -Headers @{"X-aws-ec2-metadata-token-ttl-seconds"="21600"}
           $CWInstanceId = Invoke-RestMethod -Uri http://169.254.169.254/latest/meta-data/instance-id -Headers @{"X-aws-ec2-metadata-token"=$Token}
-          $CWConfig = @"
-          {
-            "logs": {
-              "logs_collected": {
-                "files": {
-                  "collect_list": [
-                    {
-                      "file_path": "C:\\actions-runner\\_diag\\Runner_*.log",
-                      "log_group_name": "/ec2/runners/$REPO/amd64-windows",
-                      "log_stream_name": "$CWInstanceId/runner-diag",
-                      "retention_in_days": 30
-                    },
-                    {
-                      "file_path": "C:\\UserData.log",
-                      "log_group_name": "/ec2/runners/$REPO/amd64-windows",
-                      "log_stream_name": "$CWInstanceId/userdata",
-                      "retention_in_days": 30
-                    },
-                    {
-                      "file_path": "C:\\StartupScript.log",
-                      "log_group_name": "/ec2/runners/$REPO/amd64-windows",
-                      "log_stream_name": "$CWInstanceId/startup",
-                      "retention_in_days": 30
-                    }
-                  ]
-                }
-              }
-            }
-          }
-"@
+          $CWConfig = '{"logs":{"logs_collected":{"files":{"collect_list":[{"file_path":"C:\\actions-runner\\_diag\\Runner_*.log","log_group_name":"/ec2/runners/' + $REPO + '/amd64-windows","log_stream_name":"' + $CWInstanceId + '/runner-diag","retention_in_days":30},{"file_path":"C:\\UserData.log","log_group_name":"/ec2/runners/' + $REPO + '/amd64-windows","log_stream_name":"' + $CWInstanceId + '/userdata","retention_in_days":30},{"file_path":"C:\\StartupScript.log","log_group_name":"/ec2/runners/' + $REPO + '/amd64-windows","log_stream_name":"' + $CWInstanceId + '/startup","retention_in_days":30}]}}}}'
           Set-Content 'C:\ProgramData\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.json' $CWConfig
           & 'C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1' -a fetch-config -m ec2 -c file:C:\ProgramData\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent.json -s
 


### PR DESCRIPTION
*Description of changes:* Previous PR to add CloudWatch agent (#1105) introduced a YAML parsing error in the Windows user data script. The PowerShell heredoc terminator "@ at column 1 broke out of the YAML literal block scalar, causing EC2Launch to fail to parse user data entirely. This prevented the GitHub Actions runner from being installed on Windows instances. Fix replaces the heredoc with inline string concatenation.

*Testing done:* Validated YAML parses correctly with Python yaml parser. SSM'd into an affected Windows instance installed CloudWatch agent manually by copying setup script into runner, confirmed agent starts and config is correct:
```
ayushkp@842f5776e312 infrastructure %    aws ssm start-session --target i-0f26b6e0644578385 --region us-east-2 --profile {redacted}

Starting session with SessionId: {redacted}
Windows PowerShell
Copyright (C) Microsoft Corporation. All rights reserved.

Install the latest PowerShell for new features and improvements! https://aka.ms/PSWindows

PS C:\Windows\system32>    & 'C:\Program Files\Amazon\AmazonCloudWatchAgent\amazon-cloudwatch-agent-ctl.ps1' -a status
{
  "status": "running",
  "starttime": "2026-06-22T20:37:02",
  "configstatus": "configured",
  "version": "1.300069.0b1529"
}
PS C:\Windows\system32>    Get-Content 'C:\ProgramData\Amazon\AmazonCloudWatchAgent\Configs\file_amazon-cloudwatch-agent.json'
{"logs":{"logs_collected":{"files":{"collect_list":[{"file_path":"C:\\actions-runner\\_diag\\Runner_*.log","log_group_name":"/ec2/runners/finch/amd64-windows","log_stream_name":"i-0f26b6e0644578385/runner-diag","retention_in_days":30},{"file_pat
h":"C:\\UserData.log","log_group_name":"/ec2/runners/finch/amd64-windows","log_stream_name":"i-0f26b6e0644578385/userdata","retention_in_days":30},{"file_path":"C:\\StartupScript.log","log_group_name":"/ec2/runners/finch/amd64-windows","log_stre
am_name":"i-0f26b6e0644578385/startup","retention_in_days":30}]}}}}
PS C:\Windows\system32>    Get-Service AmazonCloudWatchAgent

Status   Name               DisplayName
------   ----               -----------
Running  AmazonCloudWatc... Amazon CloudWatch Agent
```

Also launched a fresh Windows Server 2022 instance with the fixed user data to verify end-to-end: EC2Launch parsed YAML successfully, runner v2.333.0 downloaded/extracted, CloudWatch agent installed and running via the full setup.

- [x] I've reviewed the guidance in CONTRIBUTING.md

#### License Acceptance

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
